### PR TITLE
Add link to view available models for the current epoch in quickstart.md

### DIFF
--- a/docs/host/quickstart.md
+++ b/docs/host/quickstart.md
@@ -278,6 +278,12 @@ source config.env
 
 For more details on the optimal deployment configuration, please refer to [this link](https://gonka.ai/host/benchmark-to-choose-optimal-deployment-config-for-llms/).
 
+
+You can view all models available for the current epoch at the following link:
+```
+http://node2.gonka.ai:8000/v1/governance/models
+```
+
 ### [Server] Pre-download Model Weights to Hugging Face Cache (HF_HOME)
 Inference nodes download model weights from Hugging Face.
 To make sure the model weights are ready for inference, you should download them before deployment.


### PR DESCRIPTION
## Improve Model Configuration Discoverability in Quickstart Guide

### Problem
It is not immediately obvious where users should look to find information about which models they can configure in their `node-config.json` settings. Currently, the documentation shows:

1. **Hardcoded model examples** in the configuration sections (lines 215-277) with specific model names like `Qwen/Qwen3-235B-A22B-Instruct-2507-FP8` and `Qwen/Qwen3-32B-FP8`
2. **A note about currently supported models** (lines 212-213) that may become outdated
3. **Information about checking available models via the governance API** (lines 282-285) that appears **after** the configuration examples

### Issue
Users following the quickstart guide are presented with configuration examples that include hardcoded model names, but there's no clear guidance upfront on:
- How to discover which models are actually available for the current epoch
- Where to find the authoritative source of model information
- How to verify that the model they want to configure is supported

The governance API endpoint (`http://node2.gonka.ai:8000/v1/governance/models`) is mentioned, but it's placed after the configuration sections, making it easy for users to miss this critical information when they're trying to configure their nodes.

### Proposed Solution
Restructure the documentation to:
1. **Prominently highlight** the governance API endpoint **before** showing configuration examples
2. **Explain** that users should check the governance API to see which models are available for the current epoch
3. **Emphasize** that model availability can change and users should always verify against the governance endpoint rather than relying on hardcoded examples
4. **Provide clear guidance** on how to use the information from the governance API to configure `node-config.json`

This will make it much clearer to users where to find the authoritative information about available models before they attempt to configure their nodes.
