### PR TITLE
Refine NFT landing styles and clean up SVG icons

### DIFF
--- a/docs/images/nft/icons-sprite.svg
+++ b/docs/images/nft/icons-sprite.svg
@@ -26,7 +26,6 @@
     <path d="M0 32.2857H45" stroke="currentColor" stroke-width="2"/>
   </symbol>
 
-
   <symbol id="icon-close" viewBox="0 0 45 45" fill="none">
     <path d="M37.9097 38.4099L6.08986 6.5901" stroke="currentColor" stroke-width="2"/>
     <path d="M6.19092 38.5108L38.0107 6.69098" stroke="currentColor" stroke-width="2"/>

--- a/docs/stylesheets/nft-landing.css
+++ b/docs/stylesheets/nft-landing.css
@@ -122,6 +122,7 @@ body:has(.gonka-nft-landing) {
     position: absolute;
     right: 20px;
     top: 20px;
+    color: #242424;
   }
 }
 


### PR DESCRIPTION
Removed unnecessary whitespace in icons-sprite.svg and added color styling to the NFT landing page for better visibility.