### PR TITLE
Add live demo video for node launch quickstart

### DIFF
--- a/docs/host/quickstart.md
+++ b/docs/host/quickstart.md
@@ -9,6 +9,22 @@ To join the network, you need to deploy two services:
 
 The guide describes a scenario in which both services are deployed on the same machine, and each Host has one MLNode. Services are deployed as Docker containers.
 
+!!! note "Live Demo — How to Launch a Node (Quickstart for Hosts)"
+    The video recording of the demo session for launching a node via the quickstart is available below.  
+    Some steps in the recording may differ from the instructions below, as the quickstart is updated continuously based on community feedback.  
+    Always follow the written quickstart - it reflects the current and correct procedure.
+
+    <div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%;">
+      <iframe
+        src="https://www.youtube.com/embed/DWOeHQoU_LY"
+        title="Gonka: Live Demo — How to Launch a Node (Quickstart for Hosts)"
+        frameborder="0"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+        allowfullscreen
+        style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;">
+      </iframe>
+    </div>
+
 ## Prerequisites
 This  section provides guidance on configuring your hardware infrastructure to participate in Gonka Network launch. The goal is to maximize protocol rewards by aligning your deployment with network expectations.
 


### PR DESCRIPTION
Added a note about a live demo video for launching a node, including an embedded iframe for the video.