### PR TITLE
docs(en): add Kimi K2.6 license

### DIFF
--- a/docs/model-licenses.md
+++ b/docs/model-licenses.md
@@ -3,6 +3,7 @@
 - [DeepSeek-V3](https://github.com/deepseek-ai/DeepSeek-V3/blob/main/LICENSE-MODEL)
 - [Gemma-3-27B](https://ai.google.dev/gemma/terms)
 - [gpt-oss-120b](https://huggingface.co/openai/gpt-oss-120b/blob/main/LICENSE)
+- [Kimi-k2.6](https://huggingface.co/moonshotai/Kimi-K2.6/blob/main/LICENSE)
 - [Llama-3.1-70B](https://ollama.com/library/llama3:70b/blobs/4fa551d4f938)
 - [Llama-3.1-405B](https://ollama.com/library/llama3.1:405b/blobs/0ba8f0e314b4)
 - [Qwen3-32B](https://huggingface.co/Qwen/Qwen3-32B/blob/main/LICENSE)


### PR DESCRIPTION
Added a huggingface license link for Kimi-k2.6 in the en-docs. 
(My first test PR for Gonka Docs)