### PR TITLE
docs: GitBook-style sidebar — Wallet merged into Other

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+Notable changes to the Gonka documentation site (MkDocs + Material).
+
+## Unreleased
+
+### Changed
+
+- **Navigation:** Removed the separate **Wallet** section. Pages that lived under Wallet—**Dashboard**, **Pricing**, and **Wallet & transfer guide**—are now under **Other**, together with **Announcements**, **Model licenses**, **Software upgrades**, and **Transactions & governance**. This follows a flatter, [GitBook](https://www.gitbook.com/)-style sidebar: one expandable block for ancillary topics instead of many small top-level groups.
+- **Chinese (`zh`):** Dropped the **Wallet** (`钱包`) section label in `nav_translations`; **Other** remains **其他**. Existing translations for wallet pages (e.g. dashboard, pricing) are unchanged.
+
+### Fixed / polish
+
+- **Sidebar section headers:** Collapsible groups (**Developer**, **Host**, **Other**, **Help**) use bold weight, uppercase, and normal foreground color so they no longer look like faint “inactive” labels (Material’s default `label[for]` styling).
+
+### Tooling
+
+- **`buildtools/sync-docs-nav.py`:** The transform for the docs-only build (`mkdocs.docs.yml`, `/docs/` on the site) now walks **nested** `nav` trees, so **Home** is still stripped and **Introduction** is still remapped to `index.md` correctly inside grouped entries.

--- a/buildtools/sync-docs-nav.py
+++ b/buildtools/sync-docs-nav.py
@@ -4,9 +4,9 @@
 This ensures mkdocs.yml is the single source of truth for navigation.
 The script:
   1. Reads the nav from mkdocs.yml
-  2. Strips the "Home" entry (landing lives at /, outside the docs build)
-  3. Remaps "Introduction: introduction.md" → "Introduction: index.md"
-     (prepare-stages.sh promotes introduction.md to index.md in _stage/docs/)
+  2. Strips every ``Home`` entry (landing lives at /, outside the docs build)
+  3. Remaps ``Introduction: introduction.md`` → ``Introduction: index.md`` anywhere
+     in the tree (prepare-stages.sh promotes introduction.md to index.md in _stage/docs/)
   4. Writes the transformed nav into mkdocs.docs.yml
 """
 from __future__ import annotations
@@ -20,19 +20,35 @@ import yaml
 ROOT = Path(__file__).resolve().parent.parent
 
 
-def transform_nav(nav: list) -> list:
-    """Strip Home and remap Introduction for the docs build."""
+def transform_nav_entry(entry: dict) -> dict | None:
+    """Transform one nav mapping. Return None to omit (e.g. Home in docs build)."""
+    key = next(iter(entry))
+    val = entry[key]
+    if key == "Home":
+        return None
+    if key == "Introduction" and val == "introduction.md":
+        return {"Introduction": "index.md"}
+    if isinstance(val, list):
+        children = transform_nav_list(val)
+        return {key: children}
+    return entry
+
+
+def transform_nav_list(items: list) -> list:
     out: list = []
-    for item in nav:
+    for item in items:
         if isinstance(item, dict):
-            key = next(iter(item))
-            if key == "Home":
-                continue
-            if key == "Introduction" and item[key] == "introduction.md":
-                out.append({"Introduction": "index.md"})
-                continue
-        out.append(item)
+            mapped = transform_nav_entry(item)
+            if mapped is not None:
+                out.append(mapped)
+        else:
+            out.append(item)
     return out
+
+
+def transform_nav(nav: list) -> list:
+    """Strip Home and remap Introduction for the docs build (nested nav aware)."""
+    return transform_nav_list(nav)
 
 
 def strip_nav_block(lines: list[str]) -> list[str]:

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -109,6 +109,16 @@ a.md-logo img,
 .gonka-logo img{border:0;padding:0;background:transparent;max-height:48px!important;height:auto!important;width:auto!important;}
 
 /* == 4. Navigation tweaks ====================================== */
+/* Collapsible section titles in the main sidebar (e.g. Developer, Host, Other, Help).
+   Material sets label.md-nav__link[for] to --md-default-fg-color--light (washed‑out gray);
+   that makes section headers look "inactive" and hides our emphasis unless we override. */
+.md-nav--primary .md-nav__item.md-nav__item--section.md-nav__item--nested > .md-nav__link,
+.md-nav--primary .md-nav__item.md-nav__item--section.md-nav__item--nested > .md-nav__link[for] {
+  font-weight: 700 !important;
+  text-transform: uppercase !important;
+  letter-spacing: 0.045em !important;
+  color: var(--md-default-fg-color) !important;
+}
 .md-nav__link:focus,
 .md-tabs__link--active,
 .md-nav__item .md-nav__link--active,

--- a/mkdocs.docs.yml
+++ b/mkdocs.docs.yml
@@ -20,3 +20,36 @@ extra:
 # nav is auto-generated at build time by buildtools/sync-docs-nav.py
 # from the single source of truth in mkdocs.yml (strips "Home",
 # remaps "Introduction" → index.md). Do not add nav here manually.
+
+nav:
+- Introduction: index.md
+- Glossary: glossary.md
+- Developer:
+  - Quickstart: developer/quickstart.md
+  - Details: developer/details.md
+- Host:
+  - Quickstart: host/quickstart.md
+  - Architecture: architecture.md
+  - Benchmark to Choose Optimal Deployment Config for LLMs: host/benchmark-to-choose-optimal-deployment-config-for-llms.md
+  - Collateral: host/collateral.md
+  - Genesis: host/genesis.md
+  - Hardware specifications: host/hardware-specifications.md
+  - How to edit Host public info: host/host_info.md
+  - Key management: host/key-management.md
+  - Kimi K2.6 Bootstrap: host/kimi-bootstrap.md
+  - ML Node Management: host/mlnode-management.md
+  - Multi-Model PoC: host/multi_model_poc.md
+  - Multiple nodes: host/multiple-nodes.md
+  - Network Node API: host/network-node-api.md
+- Other:
+  - Dashboard: wallet/dashboard.md
+  - Pricing: wallet/pricing.md
+  - Wallet & transfer guide: wallet/wallet-and-transfer-guide.md
+  - Announcements: release-announcements.md
+  - Model licenses: model-licenses.md
+  - Software upgrades: software-upgrades.md
+  - Transactions & governance: transactions-and-governance.md
+- Help:
+  - FAQ: FAQ.md
+  - Errors: Errors.md
+  - Get help: help.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,14 +26,14 @@ nav:
     - Multi-Model PoC: host/multi_model_poc.md
     - Multiple nodes: host/multiple-nodes.md
     - Network Node API: host/network-node-api.md
-  - Wallet:
+  - Other:
     - Dashboard: wallet/dashboard.md
     - Pricing: wallet/pricing.md
     - Wallet & transfer guide: wallet/wallet-and-transfer-guide.md
-  - Announcements: release-announcements.md
-  - Model licenses: model-licenses.md
-  - Software upgrades: software-upgrades.md
-  - Transactions & governance: transactions-and-governance.md
+    - Announcements: release-announcements.md
+    - Model licenses: model-licenses.md
+    - Software upgrades: software-upgrades.md
+    - Transactions & governance: transactions-and-governance.md
   - Help:
     - FAQ: FAQ.md
     - Errors: Errors.md
@@ -144,10 +144,10 @@ plugins:
             ML Node Management: ML 节点管理
             "Multiple nodes": 多节点
             "Network Node API": 网络节点 API
-            Wallet: 钱包
             Dashboard: 仪表盘
             Pricing: 价格
             Wallet & transfer guide: 钱包与转账指南
+            Other: 其他
             Announcements: 公告
             "Model licenses": 模型许可
             Software upgrades: 软件升级


### PR DESCRIPTION
- Group wallet pages with ancillary docs under Other; drop Wallet from nav

- Sidebar: bold uppercase section labels (Material muted label override)

- sync-docs-nav: nested nav transform for /docs/ export; refresh mkdocs.docs.yml

- Add CHANGELOG.md (Unreleased)

Предлагаю в меню сделать так же, как у GitBook. Т.е. чтобы выделить названия областей.

2. Убрал область Wallet и добавил Other

Мне кажется, так будет красивее и понятнее.

Только проверьте, может, я там что-то лишнее сделал, я не программист. Всю работу делал через Cursor.