### PR TITLE
update quickstart and multi-model PoC documentation to include 

### DIFF
--- a/docs/host/kimi-bootstrap.md
+++ b/docs/host/kimi-bootstrap.md
@@ -1,6 +1,8 @@
 # Kimi K2.6 Bootstrap
 
-Epoch 251 is when the model group `moonshotai/Kimi-K2.6` may become eligible.
+`moonshotai/Kimi-K2.6` has **passed bootstrap** and is **active** in Proof of Compute on Gonka mainnet. The timeline and transaction examples below remain useful for understanding how activation worked and for operations such as delegation; for current deployment defaults (including `node-config.json`), see the [Host Quickstart](./quickstart.md).
+
+Epoch 251 was when the model group `moonshotai/Kimi-K2.6` became eligible.
 
 This document explains how to minimize the chance of weight reductions, whether or not the model gets enough participants.
 

--- a/docs/host/multi_model_poc.md
+++ b/docs/host/multi_model_poc.md
@@ -4,7 +4,7 @@ Upgrade v0.2.12 introduces multi-model Proof-of-Compute (PoC).
 
 ## What changes in v0.2.12
 
-Before v0.2.12, the network operated a single enforced model: `Qwen/Qwen3-235B-A22B-Instruct-2507-FP8`. After v0.2.12, the network can support multiple governance-approved models. Each model has its own PoC group, parameters, and weight contribution. Participation is tracked per model. The second model introduced with this upgrade is `moonshotai/Kimi-K2.6`. The Kimi model group is scheduled to activate two epochs after the upgrade. Its coefficient is approximately 3.51× the coefficient of Qwen235B, based on relative compute complexity on the same hardware classes, including 8×H200 and 8×B200.
+Before v0.2.12, the network operated a single enforced model: `Qwen/Qwen3-235B-A22B-Instruct-2507-FP8`. After v0.2.12, the network can support multiple governance-approved models. Each model has its own PoC group, parameters, and weight contribution. Participation is tracked per model. The second model introduced with this upgrade is `moonshotai/Kimi-K2.6`; it has **passed bootstrap** and **participates in PoC** on mainnet alongside Qwen235B. Its coefficient is approximately 3.51× the coefficient of Qwen235B, based on relative compute complexity on the same hardware classes, including 8×H200 and 8×B200.
 
 ??? note "Why multi-model PoC works this way"
 

--- a/docs/host/quickstart.md
+++ b/docs/host/quickstart.md
@@ -26,8 +26,18 @@ The guide describes a scenario in which both services are deployed on the same m
 ## Prerequisites
 This  section provides guidance on configuring your hardware infrastructure to participate in Gonka Network launch. The goal is to maximize protocol rewards by aligning your deployment with network expectations.
 
-### Supported Model
-The protocol currently supports a single model for inference and Proof of Compute (PoC) `Qwen/Qwen3-235B-A22B-Instruct-2507-FP8`. This model is used for PoC v2 participation and weight assignment. 
+### Supported models
+The protocol supports **governance-approved** models for inference and Proof of Compute (PoC v2). On Gonka mainnet, each approved model has its own PoC group and reward tracking (multi-model PoC since upgrade v0.2.12).
+
+| Model ID | Role |
+|----------|------|
+| `Qwen/Qwen3-235B-A22B-Instruct-2507-FP8` | Original enforced model; still supported |
+| `moonshotai/Kimi-K2.6` | **Kimi K2.6** — active in PoC on the network (passed bootstrap; participates alongside Qwen) |
+
+You typically run **one model per ML Node** in `node-config.json`. Hosts may operate separate ML Nodes (or fleets) for Qwen and Kimi.
+
+!!! note "If you will not run every approved model"
+    Multi-model PoC tracks participation **per model**. If your hardware does **not** cover every governance-approved model, you will need on-chain **delegation** or **refusal** so your consensus weight is handled correctly for the models you skip. That is **not** required to bring a node online—you use the same **Account (cold) key** as in [Grant Permissions to ML Operational Key](#33-local-machine-grant-permissions-to-ml-operational-key), **after** registration and verification. Copy-paste commands are at the end: [Optional: PoC delegation and refusal](#optional-poc-delegation-and-refusal). For strategy and penalties, read [Multi-Model PoC — Host Operations Guide](./multi_model_poc.md).
 
 !!! note "Governance and model classification"
     - Models may be classified into a category if approved by governance.
@@ -39,9 +49,12 @@ To run a valid node, you need machines with [supported GPU(s)](/host/hardware-sp
 
 | **Model Name**                          | **ML Nodes (min)** | **Example Hardware**                            | **Minimum VRAM per ML Node** |
 |------------------------------------------|-------------------|-------------------------------------------------|----------------|
-| `Qwen/Qwen3-235B-A22B-Instruct-2507-FP8`                | ≥ 2               | 8× H200 per MLNode                              | 640 GB         |
+| `Qwen/Qwen3-235B-A22B-Instruct-2507-FP8` | ≥ 2               | 8× H200 per MLNode                              | 640 GB         |
+| `moonshotai/Kimi-K2.6`                  | ≥ 2               | 8× H200 or 8× B200 per MLNode (reference class) | 640 GB         |
 
 This is a reference architecture. You may adjust node count or hardware allocation, but we recommend following the core principle: each node should support multiple ML Nodes across all model tiers.
+
+For Kimi K2.6, the network uses a **weight coefficient** of approximately **3.51×** Qwen235B on the same reference hardware (8×H200, 8×B200). See [Multi-Model PoC — Host Operations Guide](./multi_model_poc.md). Example vLLM arguments for B200-class hosts are in [Kimi K2.6 Bootstrap](./kimi-bootstrap.md) and in the `node-config.json` examples below.
 
 More details about the optimal deployment configuration can be found [here](https://gonka.ai/host/benchmark-to-choose-optimal-deployment-config-for-llms/).
 
@@ -488,10 +501,9 @@ source config.env
 
 ### [Server] Edit Inference Node Description for the Server
 
-!!! note
-    The network currently supports the Qwen/Qwen3-235B-A22B-Instruct-2507-FP8 only. The governance makes decisions on adding or modifying supported models. For details on how model governance works and how to propose new models, see the [Transactions and Governance Guide](https://gonka.ai/transactions-and-governance/).
+Edit `node-config.json` so each ML Node entry lists the **one model** that node serves under `"models"`. Supported mainnet models include `Qwen/Qwen3-235B-A22B-Instruct-2507-FP8` and `moonshotai/Kimi-K2.6`. Governance decides the approved set; see the [Transactions and Governance Guide](https://gonka.ai/transactions-and-governance/).
 
-=== "4xH100 (same works for 8xH200 or 8xH100)"
+=== "Qwen — 4xH100 (same works for 8xH200 or 8xH100)"
 
     !!! note "edit node-config.json"
         ```
@@ -513,18 +525,63 @@ source config.env
         ]
         ```
 
+=== "Kimi — 4×B200 / 8×B200 (and 8×H200 reference class)"
+
+    Use this vLLM argument set for **Kimi K2.6** on Blackwell **4×B200 or 8×B200**, and as the reference for **8×H200** on the same layout (`tensor_parallel_size` 4 with expert parallelism across eight GPUs). Adjust only if your stack or benchmarking requires it.
+
+    !!! note "edit node-config.json"
+        ```
+        [
+            {
+                "id": "node1",
+                "host": "inference",
+                "inference_port": 5000,
+                "poc_port": 8080,
+                "max_concurrent": 500,
+                "models": {
+                    "moonshotai/Kimi-K2.6": {
+                        "args": [
+                            "--tensor-parallel-size", "4",
+                            "--enable-expert-parallel",
+                            "--trust-remote-code",
+                            "--mm-encoder-tp-mode", "data",
+                            "--tool-call-parser", "kimi_k2",
+                            "--reasoning-parser", "kimi_k2",
+                            "--attention-backend", "FLASHINFER_MLA",
+                            "--disable-custom-all-reduce",
+                            "--gpu-memory-utilization", "0.95",
+                            "--max-num-seqs", "128",
+                            "--max-model-len", "240000"
+                        ]
+                    }
+                }
+            }
+        ]
+        ```
+
+    The same `"models"` block is used when registering or updating a node via the API; see [Kimi K2.6 Bootstrap](./kimi-bootstrap.md) for an equivalent `curl` example.
+
 For more details on the optimal deployment configuration, please refer to [this link](https://gonka.ai/host/benchmark-to-choose-optimal-deployment-config-for-llms/).
 
 ### [Server] Pre-download Model Weights to Hugging Face Cache (HF_HOME)
 Inference nodes download model weights from Hugging Face.
 To make sure the model weights are ready for inference, you should download them before deployment.
 
-=== "8xH100, 8xH200 or Other GPUs"
+=== "Qwen — 8xH100, 8xH200 or other GPUs"
 
     ```bash
     mkdir -p $HF_HOME
     huggingface-cli download Qwen/Qwen3-235B-A22B-Instruct-2507-FP8
     ```
+
+=== "Kimi K2.6"
+
+    ```bash
+    mkdir -p $HF_HOME
+    huggingface-cli download moonshotai/Kimi-K2.6
+    ```
+
+    Model license: see [Model licenses](../model-licenses.md). For operational notes and on-chain options (intent, delegation), see [Kimi K2.6 Bootstrap](./kimi-bootstrap.md).
 
 ## Launch Nodes
     
@@ -786,7 +843,7 @@ docker compose -f docker-compose.yml -f docker-compose.mlnode.yml up -d
 ```
 <!-- CONDITION END -->
 
-## Verify Node Status
+## Verify Node Status {#verify-node-status}
 
 <!-- CONDITION START: data-show-when='["protocolHttps"]' -->
 Verify HTTPS is working:
@@ -836,9 +893,97 @@ curl http://node2.gonka.ai:8000/chain-rpc/status
 
 Once your node is visible in the Dashboard, you may also want to update your public profile (host name, website, avatar). This helps other participants identify your node in the network. You can find [the instructions here](https://gonka.ai/host/validator_info/).
 
-!!! important "Required next steps"
-    After completing this guide, continue with the [Multi-Model PoC Host Operations Guide](./multi_model_poc.md) and [Kimi K2.6 Bootstrap](./kimi-bootstrap.md).
-    This is required reading for hosts because Upgrade v0.2.12 changes how model participation is tracked on-chain.
+## Optional: PoC delegation and refusal {#optional-poc-delegation-and-refusal}
+
+Use this section **after** your Host is registered, the ML Operational Key is authorized, and you can [verify](#verify-node-status) participation—typically from your **local machine** with the **Account (cold) key** (`gonka-account-key`). Nothing here is required to start containers; it applies when you **do not** run every governance-approved model on your own GPUs and must **delegate** PoC voting to another participant, **refuse** delegation, or compare timing against `params`.
+
+For each `model_id` you either run the model (PoC commits from your stack) or signal on-chain. **Delegation** is the common choice when you trust a host who runs that model; **refuse** is an explicit opt-out. Background: [Multi-Model PoC — Host Operations Guide](./multi_model_poc.md).
+
+Set `NODE` to any synced chain RPC (same pattern as `grant-ml-ops-permissions`: seed API URL from `config.env` with `/chain-rpc/` appended).
+
+```bash
+export NODE="<PUBLIC_CHAIN_RPC>"   # e.g. https://node2.gonka.ai:8000/chain-rpc/
+export CHAIN_ID="gonka-mainnet"
+export KEY="gonka-account-key"
+export KEYRING_BACKEND="file"
+```
+
+Check governance parameters (penalties, `penalty_start_epoch`, etc.):
+
+```bash
+./inferenced query inference params --node "$NODE" -o json
+```
+
+**Inspect your PoC delegation / refusal / intent state** (all models):
+
+```bash
+MY_ADDR="$(./inferenced keys show "$KEY" -a --keyring-backend "$KEYRING_BACKEND")"
+./inferenced query inference poc-delegation "$MY_ADDR" --node "$NODE" -o json
+```
+
+**Delegate** — attach your weight for that model's PoC validation to `DELEGATEE` (their `gonka1…` address). Example for Kimi:
+
+```bash
+MODEL="moonshotai/Kimi-K2.6"
+DELEGATEE="gonka1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+
+./inferenced tx inference set-poc-delegation "$MODEL" "$DELEGATEE" \
+  --from "$KEY" \
+  --node "$NODE" \
+  --chain-id "$CHAIN_ID" \
+  --keyring-backend "$KEYRING_BACKEND" \
+  --gas auto \
+  --gas-adjustment 1.3 \
+  -y
+```
+
+Example for Qwen (e.g. you run Kimi only on your GPUs):
+
+```bash
+MODEL="Qwen/Qwen3-235B-A22B-Instruct-2507-FP8"
+DELEGATEE="gonka1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+
+./inferenced tx inference set-poc-delegation "$MODEL" "$DELEGATEE" \
+  --from "$KEY" \
+  --node "$NODE" \
+  --chain-id "$CHAIN_ID" \
+  --keyring-backend "$KEYRING_BACKEND" \
+  --gas auto \
+  --gas-adjustment 1.3 \
+  -y
+```
+
+**Clear** a delegation for one model:
+
+```bash
+MODEL="moonshotai/Kimi-K2.6"
+
+./inferenced tx inference set-poc-delegation "$MODEL" "" \
+  --from "$KEY" \
+  --node "$NODE" \
+  --chain-id "$CHAIN_ID" \
+  --keyring-backend "$KEYRING_BACKEND" \
+  --gas auto \
+  --gas-adjustment 1.3 \
+  -y
+```
+
+**Refuse** delegation for one model (explicit on-chain “no”):
+
+```bash
+MODEL="moonshotai/Kimi-K2.6"
+
+./inferenced tx inference refuse-poc-delegation "$MODEL" \
+  --from "$KEY" \
+  --node "$NODE" \
+  --chain-id "$CHAIN_ID" \
+  --keyring-backend "$KEYRING_BACKEND" \
+  --gas auto \
+  --gas-adjustment 1.3 \
+  -y
+```
+
+`declare-poc-intent` applies mainly to **new model bootstrap** windows; see [Kimi K2.6 Bootstrap](./kimi-bootstrap.md). More commands and edge cases: [Multi-Model PoC — Host Operations Guide](./multi_model_poc.md#copy-paste-setup-commands).
 
 ## Stopping and Cleaning Up Your Node
 

--- a/docs/zh/host/quickstart.md
+++ b/docs/zh/host/quickstart.md
@@ -29,7 +29,17 @@
 
 ### 支持的模型
 
-当前协议仅支持一种用于推理与计算证明（PoC）的模型：`Qwen/Qwen3-235B-A22B-Instruct-2507-FP8`。该模型用于 PoC v2 参与与权重分配。
+协议支持经**治理批准**、用于推理与计算证明（PoC v2）的模型。自升级 v0.2.12 起为**多模型 PoC**：在 Gonka 主网上，每个获批模型有各自的 PoC 组与奖励统计。
+
+| 模型 ID | 说明 |
+|----------|------|
+| `Qwen/Qwen3-235B-A22B-Instruct-2507-FP8` | 原先强制使用的模型；继续支持 |
+| `moonshotai/Kimi-K2.6` | **Kimi K2.6** — 已在网络上参与 PoC（已过 bootstrap，与 Qwen 并行） |
+
+通常在 `node-config.json` 中**每个 ML 节点只服务一个模型**（`models` 下的一项）。若需同时覆盖 Qwen 与 Kimi，请使用多个 ML 节点（或多台机器）。
+
+!!! note "若无法在本机运行全部获批模型"
+    多模型 PoC **按模型**统计参与。若硬件无法覆盖每一位治理批准的模型，需要通过链上**委托**或**拒绝**，使共识权重在各模型上被正确计入。这与「先把节点跑起来」**无关**——仍使用**账户（冷）密钥**（与 **步骤 3.3「向 ML 运营密钥授予权限」** 相同 keyring），在注册并**验证节点**之后再执行。完整命令见文末 [可选：PoC 委托与拒绝](#optional-poc-delegation-and-refusal)。策略与惩罚说明见 [多模型 PoC — 主机操作指南](/host/multi_model_poc/)。
 
 !!! note "治理与模型分类"
     - 经治理批准后，模型可被归入某类。
@@ -42,11 +52,12 @@
 
 | **模型名称**                          | **ML 节点（最少）** | **示例硬件**                            | **每 ML 节点最小显存** |
 |------------------------------------------|-------------------|-------------------------------------------------|----------------|
-| `Qwen/Qwen3-235B-A22B-Instruct-2507-FP8`                | ≥ 2               | 每 ML 节点 8× H200                              | 640 GB         |
+| `Qwen/Qwen3-235B-A22B-Instruct-2507-FP8` | ≥ 2               | 每 ML 节点 8× H200                              | 640 GB         |
+| `moonshotai/Kimi-K2.6`                  | ≥ 2               | 每 ML 节点 8× H200 或 8× B200（参考档位）       | 640 GB         |
 
 此为参考架构。您可调整节点数量或硬件分配，但建议遵循核心原则：每个节点应在各模型层级支持多个 ML 节点。
 
-更多关于最优部署配置的说明见[此处](https://gonka.ai/host/benchmark-to-choose-optimal-deployment-config-for-llms/)。
+Kimi K2.6 在相同参考硬件（8×H200、8×B200）上相对 Qwen235B 的 PoC 权重系数约为 **3.51×**。详见 [多模型 PoC — 主机操作指南](/host/multi_model_poc/)。B200 档位的示例 vLLM 参数见下文 `node-config.json` 与 [Kimi K2.6 Bootstrap](/host/kimi-bootstrap/)。
 
 承载网络节点的服务器应具备：
 
@@ -466,10 +477,9 @@ source config.env
 
 ### [服务器] 编辑服务器推理节点描述
 
-!!! note
-    当前网络仅支持 Qwen/Qwen3-235B-A22B-Instruct-2507-FP8。是否新增或修改支持的模型由治理决定。治理机制及如何提议新模型见 [交易与治理指南](https://gonka.ai/transactions-and-governance/)。
+编辑 `node-config.json`，使每个 ML 节点在 `"models"` 中声明其运行的**单个模型**。主网支持的模型包括 `Qwen/Qwen3-235B-A22B-Instruct-2507-FP8` 与 `moonshotai/Kimi-K2.6`。批准列表由治理决定；详见 [交易与治理指南](https://gonka.ai/transactions-and-governance/)。
 
-=== "4xH100（同样适用于 8xH200 或 8xH100）"
+=== "Qwen — 4xH100（同样适用于 8xH200 或 8xH100）"
 
     !!! note "编辑 node-config.json"
         ```
@@ -491,18 +501,63 @@ source config.env
         ]
         ```
 
+=== "Kimi — 4×B200 / 8×B200（及 8×H200 参考档位）"
+
+    以下 vLLM 参数适用于 Blackwell **4×B200 或 8×B200** 上的 **Kimi K2.6**，并作为 **8×H200** 同布局的参考（`tensor_parallel_size` 为 4，且在八卡上使用 expert parallelism）。请仅在压测或运维要求下再调整。
+
+    !!! note "编辑 node-config.json"
+        ```
+        [
+            {
+                "id": "node1",
+                "host": "inference",
+                "inference_port": 5000,
+                "poc_port": 8080,
+                "max_concurrent": 500,
+                "models": {
+                    "moonshotai/Kimi-K2.6": {
+                        "args": [
+                            "--tensor-parallel-size", "4",
+                            "--enable-expert-parallel",
+                            "--trust-remote-code",
+                            "--mm-encoder-tp-mode", "data",
+                            "--tool-call-parser", "kimi_k2",
+                            "--reasoning-parser", "kimi_k2",
+                            "--attention-backend", "FLASHINFER_MLA",
+                            "--disable-custom-all-reduce",
+                            "--gpu-memory-utilization", "0.95",
+                            "--max-num-seqs", "128",
+                            "--max-model-len", "240000"
+                        ]
+                    }
+                }
+            }
+        ]
+        ```
+
+    通过 API 注册或更新节点时使用相同的 `"models"` 块；等效的 `curl` 示例见 [Kimi K2.6 Bootstrap](/host/kimi-bootstrap/)。
+
 更多关于最优部署配置的说明请参阅 [此链接](https://gonka.ai/host/benchmark-to-choose-optimal-deployment-config-for-llms/)。
 
 ### [服务器] 将模型权重预下载到 Hugging Face 缓存（HF_HOME）
 
 推理节点从 Hugging Face 下载模型权重。为确保推理前权重已就绪，应在部署前下载。
 
-=== "8xH100、8xH200 或其他 GPU"
+=== "Qwen — 8xH100、8xH200 或其他 GPU"
 
     ```bash
     mkdir -p $HF_HOME
     huggingface-cli download Qwen/Qwen3-235B-A22B-Instruct-2507-FP8
     ```
+
+=== "Kimi K2.6"
+
+    ```bash
+    mkdir -p $HF_HOME
+    huggingface-cli download moonshotai/Kimi-K2.6
+    ```
+
+    许可证见 [Model licenses](/model-licenses/)。链上操作（intent、委托等）见 [Kimi K2.6 Bootstrap](/host/kimi-bootstrap/)。
 
 ## 启动节点
     
@@ -764,7 +819,7 @@ docker compose -f docker-compose.yml -f docker-compose.mlnode.yml up -d
 ```
 <!-- CONDITION END -->
 
-## 验证节点状态
+## 验证节点状态 {#verify-node-status}
 
 <!-- CONDITION START: data-show-when='["protocolHttps"]' -->
 验证 HTTPS 是否正常：
@@ -813,6 +868,98 @@ curl http://node2.gonka.ai:8000/chain-rpc/status
 ```
 
 当节点在仪表盘中可见后，您也可以更新公开资料（主机名、网站、头像），便于其他参与者识别。说明见[此处](https://gonka.ai/host/validator_info/)。
+
+## 可选：PoC 委托与拒绝 {#optional-poc-delegation-and-refusal}
+
+在主机已注册、已完成 ML 运营密钥授权，并能[验证节点状态](#verify-node-status)之后，再在**本机**用**账户（冷）密钥**（`gonka-account-key`）执行本节。启动容器**不需要**这些交易；仅当您**未**在本机 GPU 上运行某一获批模型，需要**委托** PoC 投票、**拒绝**委托或对照 `params` 确认惩罚时间时使用。
+
+对每个 `model_id`，要么自行运行该模型（由您的栈提交 PoC），要么链上声明。**委托**常见于信任另一位运行该模型的主机；**拒绝**为明确退出。背景见 [多模型 PoC — 主机操作指南](/host/multi_model_poc/)。
+
+将 `NODE` 设为任意已同步的 chain RPC（与 `grant-ml-ops-permissions` 相同：`config.env` 中种子 API + `/chain-rpc/`）。
+
+```bash
+export NODE="<PUBLIC_CHAIN_RPC>"   # 例如 https://node2.gonka.ai:8000/chain-rpc/
+export CHAIN_ID="gonka-mainnet"
+export KEY="gonka-account-key"
+export KEYRING_BACKEND="file"
+```
+
+查询治理参数（惩罚、`penalty_start_epoch` 等）：
+
+```bash
+./inferenced query inference params --node "$NODE" -o json
+```
+
+**查询当前 PoC 委托 / 拒绝 / 意向**（所有模型）：
+
+```bash
+MY_ADDR="$(./inferenced keys show "$KEY" -a --keyring-backend "$KEYRING_BACKEND")"
+./inferenced query inference poc-delegation "$MY_ADDR" --node "$NODE" -o json
+```
+
+**委托** — 将该模型的 PoC 验证权重关联到 `DELEGATEE`（对方的 `gonka1…` 地址）。Kimi 示例：
+
+```bash
+MODEL="moonshotai/Kimi-K2.6"
+DELEGATEE="gonka1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+
+./inferenced tx inference set-poc-delegation "$MODEL" "$DELEGATEE" \
+  --from "$KEY" \
+  --node "$NODE" \
+  --chain-id "$CHAIN_ID" \
+  --keyring-backend "$KEYRING_BACKEND" \
+  --gas auto \
+  --gas-adjustment 1.3 \
+  -y
+```
+
+例如 GPU 上只跑 Kimi、不跑 Qwen，可对 Qwen 委托：
+
+```bash
+MODEL="Qwen/Qwen3-235B-A22B-Instruct-2507-FP8"
+DELEGATEE="gonka1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+
+./inferenced tx inference set-poc-delegation "$MODEL" "$DELEGATEE" \
+  --from "$KEY" \
+  --node "$NODE" \
+  --chain-id "$CHAIN_ID" \
+  --keyring-backend "$KEYRING_BACKEND" \
+  --gas auto \
+  --gas-adjustment 1.3 \
+  -y
+```
+
+**取消**某一模型的委托：
+
+```bash
+MODEL="moonshotai/Kimi-K2.6"
+
+./inferenced tx inference set-poc-delegation "$MODEL" "" \
+  --from "$KEY" \
+  --node "$NODE" \
+  --chain-id "$CHAIN_ID" \
+  --keyring-backend "$KEYRING_BACKEND" \
+  --gas auto \
+  --gas-adjustment 1.3 \
+  -y
+```
+
+**拒绝**委托：
+
+```bash
+MODEL="moonshotai/Kimi-K2.6"
+
+./inferenced tx inference refuse-poc-delegation "$MODEL" \
+  --from "$KEY" \
+  --node "$NODE" \
+  --chain-id "$CHAIN_ID" \
+  --keyring-backend "$KEYRING_BACKEND" \
+  --gas auto \
+  --gas-adjustment 1.3 \
+  -y
+```
+
+`declare-poc-intent` 多用于**新模型 bootstrap**；见 [Kimi K2.6 Bootstrap](/host/kimi-bootstrap/)。更多命令见 [多模型 PoC — 主机操作指南](/host/multi_model_poc/#copy-paste-setup-commands)。
 
 ## 停止与清理节点
 


### PR DESCRIPTION
support for `moonshotai/Kimi-K2.6`, detailing model roles, configuration, and delegation processes. Update Kimi bootstrap information to reflect its active status in Proof of Compute on mainnet.