### PR TITLE
Restructure docs navigation for clearer information architecture

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,36 +7,47 @@ site_description: >-
 # Content
 nav:
   - Home: index.md
-  - Introduction: introduction.md
-  - Glossary: glossary.md
+
+  - Learn:
+    - Introduction: introduction.md
+    - Architecture: architecture.md
+    - Glossary: glossary.md
+
   - Developer:
     - Quickstart: developer/quickstart.md
     - Details: developer/details.md
+
   - Host:
-    - Quickstart: host/quickstart.md
-    - Architecture: architecture.md
-    - Benchmark to Choose Optimal Deployment Config for LLMs: host/benchmark-to-choose-optimal-deployment-config-for-llms.md
-    - Collateral: host/collateral.md
-    - Genesis: host/genesis.md
-    - Hardware specifications: host/hardware-specifications.md
-    - How to edit Host public info: host/host_info.md
-    - Key management: host/key-management.md
-    - Kimi K2.6 Bootstrap: host/kimi-bootstrap.md
-    - ML Node Management: host/mlnode-management.md
-    - Multi-Model PoC: host/multi_model_poc.md
-    - Multiple nodes: host/multiple-nodes.md
-    - Network Node API: host/network-node-api.md
-  - Wallet:
+    - Get started:
+      - Quickstart: host/quickstart.md
+      - Hardware specifications: host/hardware-specifications.md
+      - Key management: host/key-management.md
+      - Collateral: host/collateral.md
+      - Genesis: host/genesis.md
+    - Operate:
+      - ML Node management: host/mlnode-management.md
+      - Multiple nodes: host/multiple-nodes.md
+      - Edit public host info: host/host_info.md
+      - Network Node API: host/network-node-api.md
+    - Models & benchmarks:
+      - Multi-Model PoC: host/multi_model_poc.md
+      - Kimi K2.6 bootstrap: host/kimi-bootstrap.md
+      - Deployment benchmark: host/benchmark-to-choose-optimal-deployment-config-for-llms.md
+
+  - Wallet & Tokens:
+    - Wallet & transfer guide: wallet/wallet-and-transfer-guide.md
     - Dashboard: wallet/dashboard.md
     - Pricing: wallet/pricing.md
-    - Wallet & transfer guide: wallet/wallet-and-transfer-guide.md
-  - Announcements: release-announcements.md
-  - Model licenses: model-licenses.md
-  - Software upgrades: software-upgrades.md
-  - Transactions & governance: transactions-and-governance.md
-  - Help:
-    - FAQ: FAQ.md
+
+  - Reference:
+    - Transactions & governance: transactions-and-governance.md
+    - Software upgrades: software-upgrades.md
+    - Model licenses: model-licenses.md
     - Errors: Errors.md
+
+  - Resources:
+    - Release announcements: release-announcements.md
+    - FAQ: FAQ.md
     - Get help: help.md
 
 # Visual
@@ -128,33 +139,40 @@ plugins:
           build: true
           nav_translations:
             Home: 首页
+            Learn: 了解
             Introduction: 介绍
+            Architecture: 架构
             Glossary: 术语表
             Developer: 开发者
             Quickstart: 快速上手
             Details: 细节
             Host: 主机
-            Architecture: 架构
-            Benchmark to Choose Optimal Deployment Config for LLMs: LLM 最佳部署配置基准测试
-            Genesis: 创世
+            Get started: 入门
             Hardware specifications: 硬件规格
-            How to edit Host public info: 如何编辑主机公开信息
-            Collateral: 抵押
             Key management: 密钥管理
-            ML Node Management: ML 节点管理
+            Collateral: 抵押
+            Genesis: 创世
+            Operate: 运维
+            ML Node management: ML 节点管理
             "Multiple nodes": 多节点
+            Edit public host info: 编辑主机公开信息
             "Network Node API": 网络节点 API
-            Wallet: 钱包
+            Models & benchmarks: 模型与基准测试
+            Multi-Model PoC: 多模型 PoC
+            Kimi K2.6 bootstrap: Kimi K2.6 引导
+            Deployment benchmark: 部署基准测试
+            Wallet & Tokens: 钱包与代币
+            Wallet & transfer guide: 钱包与转账指南
             Dashboard: 仪表盘
             Pricing: 价格
-            Wallet & transfer guide: 钱包与转账指南
-            Announcements: 公告
-            "Model licenses": 模型许可
-            Software upgrades: 软件升级
+            Reference: 参考
             Transactions & governance: 交易与治理
-            Help: 帮助
-            FAQ: 常见问题
+            Software upgrades: 软件升级
+            "Model licenses": 模型许可
             Errors: 错误
+            Resources: 资源
+            Release announcements: 发布公告
+            FAQ: 常见问题
             "Get help": 获取支持
 
 strict: true


### PR DESCRIPTION
Reorganize top-level nav from 11 flat items into 7 grouped sections (Learn, Developer, Host, Wallet & Tokens, Reference, Resources) so that related content sits together and the sidebar matches industry-standard L1/protocol docs.

Notable changes:
- New "Learn" group with Introduction, Architecture, Glossary (Architecture moved out of Host; conceptually it applies to everyone)
- Host's 12 flat pages split into "Get started", "Operate", "Models & benchmarks" subgroups
- Loose top-level pages (Model licenses, Software upgrades, Transactions & governance, Errors) consolidated under "Reference"
- Release announcements, FAQ, Get help moved into "Resources"
- Shortened a few long/inconsistent labels (e.g. "How to edit Host public info" -> "Edit public host info", long benchmark title -> "Deployment benchmark")
- Chinese nav_translations updated to match new keys

No content files moved or added; only mkdocs.yml is touched.