### PR TITLE
Recurse sync-docs-nav.py so nested Introduction is remapped to index.md

### DIFF
--- a/buildtools/sync-docs-nav.py
+++ b/buildtools/sync-docs-nav.py
@@ -21,15 +21,24 @@ ROOT = Path(__file__).resolve().parent.parent
 
 
 def transform_nav(nav: list) -> list:
-    """Strip Home and remap Introduction for the docs build."""
+    """Strip Home and remap Introduction for the docs build (recursive).
+
+    The remap of ``Introduction: introduction.md`` -> ``Introduction: index.md``
+    is applied at any depth, because Introduction may live under a parent
+    section (e.g. ``Learn``) rather than at the top level.
+    """
     out: list = []
     for item in nav:
         if isinstance(item, dict):
             key = next(iter(item))
+            value = item[key]
             if key == "Home":
                 continue
-            if key == "Introduction" and item[key] == "introduction.md":
+            if key == "Introduction" and value == "introduction.md":
                 out.append({"Introduction": "index.md"})
+                continue
+            if isinstance(value, list):
+                out.append({key: transform_nav(value)})
                 continue
         out.append(item)
     return out


### PR DESCRIPTION
After the nav restructure, the Introduction entry lives under the new Learn section rather than at the top level. The previous top-level-only loop left "Introduction: introduction.md" untouched in the docs build, which fails the strict build because prepare-stages.sh removes introduction.md from _stage/docs/ in favor of index.md.

Make transform_nav() recurse into nested lists so the remap applies at any depth. Stripping "Home" remains top-level-only by design.

Fixes CI build:
  WARNING - A reference to 'introduction.md' is included in the 'nav'
  configuration, which is not found in the documentation files.
  WARNING - mkdocs_static_i18n: Could not find a homepage for locale 'en'/'zh'