### PR TITLE
Add Cross-Chain Transfers section (Ethereum bridge preview + IBC USDT)

### DIFF
--- a/docs/cross-chain-transfers/eth-to-gonka.md
+++ b/docs/cross-chain-transfers/eth-to-gonka.md
@@ -1,0 +1,72 @@
+# Move ETH to Gonka (WETH)
+
+This guide shows how to move the native Ethereum coin (**ETH**) to Gonka as
+**WETH** (wrapped ETH, a CW-20 token on Gonka) via the native Ethereum bridge.
+
+!!! danger "Bridge not yet active"
+    The Gonka Ethereum bridge contract is **not yet deployed** on Ethereum
+    mainnet. The address shown as `<bridge-contract-address>` below is a
+    **placeholder**. The actual address will be published in
+    [Release announcements](../release-announcements.md) once the bridge is
+    activated.
+
+    **Do not send any funds** to the bridge contract until the launch is
+    officially announced. ETH sent before activation will be lost.
+
+    This guide is published as a preview so the community can review the
+    flow ahead of the launch. Detailed commands will be added before launch.
+
+## How it works
+
+To move native ETH to Gonka, you transfer ETH to the bridge contract on
+Ethereum. The ETH becomes **locked** in that contract. Once the transaction
+is recognized by Gonka consensus, the bridge **mints** WETH on the Gonka
+chain as a CW-20 token.
+
+After minting, ownership of the wrapped tokens is assigned to the Gonka
+address derived from the **same private/public key** that signed the ETH
+deposit on Ethereum.
+
+## Same-key addressing
+
+The Gonka and Ethereum addresses used by the bridge are derived from the
+same private/public key.
+
+- If you want to use an existing Ethereum address that already holds ETH,
+  generate the matching Gonka address from the same private key — that Gonka
+  address will receive WETH.
+- If instead you want to use an existing Gonka address, generate the
+  corresponding Ethereum address from the same private key, fund it with
+  ETH, and ensure you have enough additional ETH for gas.
+
+## A) Send ETH to the bridge contract on Ethereum
+
+!!! info "Detailed instructions coming soon"
+    Step-by-step commands for the ETH → WETH flow will be published here
+    before the bridge launch. In short, ETH is sent to the bridge contract
+    on Ethereum, where it is locked; once the deposit is recognized by Gonka
+    consensus, WETH (a CW-20 token) is minted on Gonka to the corresponding
+    Gonka address.
+
+## B) Check WETH balance on Gonka
+
+WETH is a CW-20 token on Gonka, so once minted it can be queried like any
+other wrapped token:
+
+```bash
+curl "https://node2.gonka.ai:8433/chain-api/productscience/inference/inference/wrapped_token_balances/{gonkaAddress}"
+```
+
+The response lists each wrapped asset owned by the Gonka address, including
+its `symbol`, `wrappedContractAddress` (CW-20 address on Gonka), and
+`formatted_balance`. See [Wrap ERC-20 tokens (USDT)](wrap-erc20-tokens.md)
+for an example response and for transferring CW-20 tokens between Gonka
+accounts.
+
+## Withdrawing WETH back to Ethereum
+
+The withdrawal flow (burn WETH on Gonka → BLS signature → release ETH on
+Ethereum) follows the same pattern as the
+[wrapped USDT withdrawal](wrap-erc20-tokens.md#d-withdraw-wrapped-usdt-back-to-ethereum).
+Detailed commands and the matching Hardhat script will be published here
+before the bridge launch.

--- a/docs/cross-chain-transfers/gnk-to-ethereum.md
+++ b/docs/cross-chain-transfers/gnk-to-ethereum.md
@@ -1,0 +1,113 @@
+# Move GNK to Ethereum (WGNK)
+
+This guide shows how to move the native Gonka coin (**GNK**) to Ethereum as
+**WGNK** (wrapped GNK) via the native Ethereum bridge.
+
+!!! danger "Bridge not yet active"
+    The Gonka Ethereum bridge contract is **not yet deployed** on Ethereum
+    mainnet. The address shown as `<bridge-contract-address>` below is a
+    **placeholder**. The actual address will be published in
+    [Release announcements](../release-announcements.md) once the bridge is
+    activated.
+
+    **Do not attempt this flow** until the launch is officially announced.
+
+    This guide is published as a preview so the community can review the
+    flow ahead of the launch. Commands and parameters are subject to change.
+
+## How it works
+
+A special transaction on the Gonka chain locks GNK on an escrow account and
+triggers **BLS signature generation** by the Gonka validator set. The
+resulting BLS signature can then be used to send a **mint** command to the
+bridge contract on Ethereum, which verifies the signature and mints WGNK to
+the target Ethereum address.
+
+## A) Request Mint WGNK on Ethereum
+
+Submit the request from Gonka. This locks GNK on the escrow account and
+triggers BLS signature generation:
+
+```bash
+./inferenced \
+  tx inference request-bridge-mint \
+  <amount> \
+  "0xYourEthereumAddr" \
+  "ethereum" \
+  --from <your_key_name> \
+  --chain-id gonka-mainnet \
+  --gas auto \
+  -y \
+  --node http://node2.gonka.ai:8000/chain-rpc/
+```
+
+Expected output:
+
+```
+...
+txhash: 12E8ABCA5A35D73042564FDF6D686424F742414EEC172450AB6EDA34BD1F0805
+```
+
+Wait a couple of blocks and check the transaction:
+
+```bash
+./inferenced query tx 12E8ABCA5A35D73042564FDF6D686424F742414EEC172450AB6EDA34BD1F0805
+```
+
+The result contains:
+
+- `"code": 0` — success
+- `request_id: "vSTWiN1pvooxcFoDLzePCEq3x/C5NQ+jFMvfcEozCm4="` — the request
+  ID for the next step (base64-encoded)
+
+Convert the request ID to hex:
+
+```bash
+echo "vSTWiN1pvooxcFoDLzePCEq3x/C5NQ+jFMvfcEozCm4=" | base64 -d | xxd -p -c 256
+# bd24d688dd69be8a31705a032f378f084ab7c7f0b9350fa314cbdf704a330a6e
+```
+
+!!! note "Gas estimation"
+    `--gas auto` may produce an incorrect gas estimate. If the transaction
+    fails, rerun with an explicit `--gas` value (for example `--gas 200000`).
+
+## B) Get BLS signature status
+
+Poll the BLS signature endpoint with the hex request ID until the signature
+is available:
+
+```bash
+curl "https://node2.gonka.ai:8433/v1/bls/signatures/<REQUEST_ID_HEX>" \
+  | jq -r '
+    {
+      uncompressed_signature_128: .uncompressed_signature_128,
+      current_epoch_id: .signing_request.current_epoch_id,
+      request_id: .signing_request.request_id
+    }
+  '
+```
+
+The response includes:
+
+- `current_epoch_id` — epoch of the request
+- `request_id` — 32-byte hash used on Gonka
+- `uncompressed_signature_128` — the BLS signature you'll submit to the
+  bridge contract on Ethereum
+
+## C) Submit mint command on Ethereum
+
+Use the [`mint-wgnk.js`](https://github.com/gonka-ai/gonka/blob/gm/contracts/proposals/ethereum-bridge-contact/mint-wgnk.js)
+script to invoke the bridge contract on Ethereum with the BLS signature:
+
+```bash
+HARDHAT_NETWORK=mainnet node mint-wgnk.js \
+  <bridge-contract-address> \
+  <current_epoch_id> \
+  <request_id> \
+  <0xYourEthereumAddr> \
+  <amount> \
+  <uncompressed_signature_128>
+```
+
+The bridge contract verifies the signature and parameters, then mints WGNK
+on Ethereum and assigns ownership to `<0xYourEthereumAddr>`.

--- a/docs/cross-chain-transfers/ibc-usdt-withdrawal.md
+++ b/docs/cross-chain-transfers/ibc-usdt-withdrawal.md
@@ -1,0 +1,246 @@
+# Withdraw IBC USDT via Kava
+
+Since the Gonka community pool holds **IBC USDT**, and some proposal payments
+and community rewards may be paid in IBC USDT, this guide explains how to
+move IBC USDT off Gonka via Kava.
+
+The route is: **Gonka → Kava Cosmos → Kava EVM → Ethereum**. You can stop
+after any completed leg — keep IBC USDT on Kava in Keplr, move it to Kava
+EVM in MetaMask, or continue all the way to Ethereum.
+
+!!! danger "This guide is about IBC USDT on Gonka / Kava Cosmos"
+    Do not confuse IBC USDT with:
+
+    - native ERC-20 USDT on Ethereum,
+    - exchange USDT balances,
+    - the wrapped CW-20 USDT minted by the (future) Gonka Ethereum bridge.
+
+    Always check the asset denom, source network, destination network, and
+    destination address before sending funds. **Treat this guide as a
+    practical community guide, not financial advice.** Routes, fees, wallet
+    UIs, and bridge availability can change, so always verify the details
+    yourself and **send a small test transaction first**.
+
+## What you will do
+
+You will move funds in three steps:
+
+1. **Gonka → Kava (Cosmos)** in Keplr.
+2. **Kava → Kava EVM** in [app.kava.io](https://app.kava.io/transfer).
+3. **Kava EVM → Ethereum** in [Stargate](https://stargate.finance/transfer).
+
+## Before you start
+
+You need:
+
+- Spendable IBC USDT on Gonka in your wallet balance.
+- Some GNK for Gonka transaction fees.
+- Some KAVA for Kava / Kava EVM fees.
+- Some ETH for Ethereum fees.
+- Keplr and MetaMask installed.
+- Willingness to do a small test transfer first.
+
+Useful official pages:
+
+- Keplr help (including IBC): [help.keplr.app](https://help.keplr.app)
+- Kava app (transfer + wKAVA): [app.kava.io](https://app.kava.io) — transfer: [app.kava.io/transfer](https://app.kava.io/transfer)
+- Kava Help Center: [help.app.kava.io](https://help.app.kava.io)
+- Stargate bridge UI: [stargate.finance/transfer](https://stargate.finance/transfer)
+- Kava on bridging USDT with Stargate: [How to Bridge USDt with Stargate](https://help.app.kava.io/en/articles/8497797-how-to-bridge-usdt-with-stargate)
+
+!!! warning "Use the right address at each step"
+    - In **Step 1**, send to your Kava Cosmos address in Keplr: `kava1...`
+    - In **Step 2**, connect both wallets inside `app.kava.io`
+    - In **Step 3**, receive on your Ethereum address in MetaMask: `0x...`
+
+## Step 1 — Send USDT from Gonka to Kava (Cosmos)
+
+In this step, you send IBC USDT from Gonka to your own Kava Cosmos address
+in Keplr.
+
+### 1. Turn on manual IBC in Keplr
+
+In Keplr:
+
+> **Settings → Advanced → Manual IBC Transfer → ON**
+
+If labels differ slightly by version, use Keplr's own docs: [help.keplr.app](https://help.keplr.app).
+
+### 2. Configure the transfer on Gonka
+
+Open **Advanced IBC Transfer** for your USDT / USDt asset.
+
+If Keplr shows **Add IBC channel** or **New IBC channel**, set:
+
+- **Destination chain:** Kava
+- **Source Channel Id:** `channel-5`
+
+Then save it.
+
+### 3. Copy your Kava address
+
+- Make sure Kava is visible in Keplr.
+- Switch to Kava.
+- Copy your full `kava1...` address.
+
+### 4. Send a small test amount
+
+On **Advanced IBC Transfer**, choose **Kava (channel-5)** from the
+destination dropdown. Then:
+
+- Paste your `kava1...` address.
+- Enter a **small test amount**.
+- Leave the memo empty unless you are sending to an exchange deposit address
+  that specifically requires a memo / tag.
+- Review the fee in `ngonka`.
+- Approve the transaction.
+
+Your USDT should appear on Kava in Keplr.
+
+## Step 2 — Move USDT from Kava IBC to Kava EVM
+
+In this step, you move the funds from Kava Cosmos to Kava EVM. **Start with
+a small test amount.**
+
+### 1. Open the Kava transfer tool
+
+Open the transfer page: [app.kava.io/transfer](https://app.kava.io/transfer).
+
+### 2. Connect both wallets
+
+- Connect **Keplr** for the Kava IBC side.
+- Connect **MetaMask** for the Kava EVM side.
+
+### 3. Set the route
+
+Choose:
+
+- **Asset:** USDT
+- **Sending chain:** Kava IBC
+- **Receiving chain:** Kava EVM
+
+Click **Transfer**. Your USDT should appear on Kava EVM in MetaMask.
+
+Kava's help article on moving USDT across Kava surfaces (your direction here
+is Cosmos → Kava EVM): [How to transfer USDt to Cosmos chains with a single click](https://help.app.kava.io/en/articles/8497788-how-to-transfer-usdt-to-cosmos-chains-with-a-single-click).
+
+### If USDT does not appear in MetaMask
+
+MetaMask may not show the token automatically. You may need to import the
+token manually. The Kava help documentation has listed this USDT contract on
+Kava EVM:
+
+```
+0x919C1c267BC06a7039e03fcc2eF738525769109c
+```
+
+!!! warning "Verify before using"
+    Before using this contract for a real transfer, **verify it again** in:
+
+    - the current [Kava Help Center](https://help.app.kava.io),
+    - the `app.kava.io` UI,
+    - your wallet's token information.
+
+If MetaMask asks for decimals, use **6**.
+
+## Step 3 — Bridge USDT from Kava EVM to Ethereum
+
+In this step, you bridge the funds from Kava EVM to Ethereum mainnet.
+
+### 1. Open Stargate
+
+Open: [stargate.finance/transfer](https://stargate.finance/transfer).
+
+Background from Kava on this bridge pattern: [How to Bridge USDt with Stargate](https://help.app.kava.io/en/articles/8497797-how-to-bridge-usdt-with-stargate).
+
+### 2. Make sure MetaMask is on Kava EVM
+
+Before you start, MetaMask should be connected to **Kava EVM**. You are
+sending **from Kava EVM**, not from Ethereum.
+
+### 3. Set the bridge route
+
+In Stargate, choose:
+
+- **From / Source:** Kava EVM
+- **To / Destination:** Ethereum
+- **Asset:** USDT
+
+In some UIs, the source may be shown simply as **Kava**. What matters is
+that it matches the network where your USDT currently sits after Step 2.
+
+### 4. Review fees and send a small test
+
+Before you confirm:
+
+- Check the bridge fee.
+- Check the estimated received amount.
+- **Send a small test first.**
+
+Then approve the transaction in MetaMask. Your USDT should appear on
+Ethereum mainnet in MetaMask.
+
+!!! warning "If Stargate does not offer this route"
+    Stop there. **Do not guess an alternative bridge.** If USDT from Kava
+    EVM to Ethereum is not shown, the route may be paused, changed, or
+    temporarily unavailable.
+
+## Step 4 — Confirm the funds on Ethereum
+
+- Switch MetaMask to **Ethereum Mainnet**.
+- Check the USDT balance for your receiving address.
+- If needed, import the token manually.
+
+A commonly used Ethereum mainnet USDT contract is:
+
+```
+0xdAC17F958D2ee523a2206206994597C13D831ec7
+```
+
+!!! warning "Verify before importing"
+    Before importing, verify the current contract in a trusted source such
+    as [Tether](https://tether.to), [Etherscan](https://etherscan.io), or
+    your wallet's verified token list.
+
+After the test amount arrives, you can repeat the same flow for the
+remaining balance.
+
+## Optional — Move KAVA between Kava Cosmos and Kava EVM
+
+If you need KAVA on the other side for gas, use [app.kava.io/evm/wkava](https://app.kava.io/evm/wkava).
+
+Step-by-step from Kava: [Send KAVA to and from Kava Cosmos and Kava EVM](https://help.app.kava.io/en/articles/8497790-how-to-send-kava-to-and-from-kava-cosmos-and-kava-evm).
+
+## Advanced — verify the Gonka IBC channel before large transfers
+
+For most users, this is not required for a small test transfer. If you want
+to verify the current Gonka outbound channel before sending a larger amount,
+you can check it with:
+
+```bash
+curl -sS "https://node1.gonka.ai:8443/chain-api/ibc/core/channel/v1/channels" \
+  | jq '.channels[] | select(.port_id=="transfer") | {gonka_channel_id:.channel_id, kava_counterparty:.counterparty.channel_id}'
+```
+
+At the time this guide was prepared, the Gonka → Kava transfer used:
+
+- **Gonka side:** `channel-5`
+- **Kava side:** `channel-161`
+
+When sending from Gonka, use the **Gonka-side channel**, which is
+`channel-5`.
+
+## Final safety reminder
+
+Before sending the full amount, make sure:
+
+- Step 1 ended with USDT visible on Kava in Keplr.
+- Step 2 ended with USDT visible on Kava EVM in MetaMask.
+- Step 3 is offering USDT from Kava EVM to Ethereum in Stargate.
+- Your test transfer completed successfully.
+
+If any of these checks fail, **stop and review** before moving the full
+balance.
+
+Stay safe, double-check everything, and always start with a small test
+transfer.

--- a/docs/cross-chain-transfers/index.md
+++ b/docs/cross-chain-transfers/index.md
@@ -1,0 +1,74 @@
+# Cross-Chain Transfers
+
+Gonka supports moving assets between Gonka and other chains through two
+independent mechanisms.
+
+## Mechanism status
+
+| Mechanism | What it covers | Status |
+|---|---|---|
+| **Ethereum bridge** (native, BLS-signed) | ERC-20 tokens (e.g. USDT), GNK, ETH | 🚧 **Preview — not yet active.** The bridge smart contract is **not yet deployed** on Ethereum mainnet. Do **not** send funds before the official launch announcement. |
+| **IBC transfers** (Cosmos IBC) | IBC USDT held on Gonka (e.g. from community pool or proposal payments) | ✅ **Live** today |
+
+## Which guide do I need?
+
+| You have… | You want to… | Use |
+|---|---|---|
+| USDT on Ethereum (ERC-20) | Use it on Gonka as wrapped CW-20 USDT | [Wrap ERC-20 tokens (USDT)](wrap-erc20-tokens.md) |
+| Wrapped CW-20 USDT on Gonka (minted by the native bridge) | Move it back to Ethereum | [Wrap ERC-20 tokens (USDT)](wrap-erc20-tokens.md) (section D onward) |
+| GNK on Gonka | Get WGNK on Ethereum | [Move GNK to Ethereum (WGNK)](gnk-to-ethereum.md) |
+| ETH on Ethereum | Use it on Gonka as WETH (CW-20) | [Move ETH to Gonka (WETH)](eth-to-gonka.md) |
+| **IBC USDT on Gonka** (e.g. community pool payments) | Move it to Ethereum via Kava | [Withdraw IBC USDT via Kava](ibc-usdt-withdrawal.md) |
+
+!!! danger "IBC USDT ≠ Wrapped USDT — do not mix the two flows"
+    There are **two different USDT-like assets** that you may encounter on Gonka:
+
+    - **IBC USDT** — USDT transferred via Cosmos IBC. This is what currently sits in the Gonka community pool and is paid out for some proposals. It moves **only** via IBC routes (see [Withdraw IBC USDT via Kava](ibc-usdt-withdrawal.md)).
+    - **Wrapped USDT (CW-20)** — minted by the native Ethereum bridge when ERC-20 USDT is locked in the bridge contract on Ethereum. This will exist only **after** the Ethereum bridge is activated.
+
+    They have different denominations, different contract addresses, and different
+    redemption paths. Sending one to the other route will result in **lost funds**.
+
+## How the Ethereum bridge works
+
+!!! danger "Bridge not yet active"
+    The Gonka Ethereum bridge contract is **not yet deployed** on Ethereum mainnet.
+    The address shown as `<bridge-contract-address>` in this section is a
+    **placeholder**. The actual contract address will be published in
+    [Release announcements](../release-announcements.md) once the bridge is
+    activated.
+
+    **Do not send any funds** to the placeholder address. Funds sent before
+    activation will be lost.
+
+The Ethereum bridge is a dedicated bridge smart contract on Ethereum (`<bridge-contract-address>`) controlled by Gonka consensus. It lets you move:
+
+- any **ERC-20** token between Ethereum and Gonka,
+- the native **ETH** coin between Ethereum and Gonka,
+- the native **GNK** coin between Gonka and Ethereum.
+
+### Ethereum → Gonka (lock & mint)
+
+To move an ERC-20 token (for example, USDT) from Ethereum to Gonka, the owner sends the token to the bridge contract on Ethereum. The tokens become **locked** in that contract. Once the deposit is recognized by Gonka consensus, the bridge **mints** a wrapped version of that ERC-20 on the Gonka chain as a **CW-20** token. Each wrapped asset has a unique CW-20 address that can only be created by the bridge.
+
+After minting, ownership of the wrapped tokens is assigned to the Gonka address derived from the **same private/public key** the owner uses on Ethereum. The owner can then freely transfer the wrapped tokens to any other Gonka account.
+
+The same lock & mint logic applies to native **ETH**: ETH sent to the bridge contract is locked there, and **WETH** is minted on Gonka as a CW-20 token assigned to the corresponding Gonka address.
+
+### Gonka → Ethereum (burn & unlock / mint)
+
+When the current owner of wrapped CW-20 tokens wants to withdraw them back to Ethereum, they submit a special transaction on the Gonka chain. This triggers **BLS signature generation** by the Gonka validator set (the status and the final signature can be polled via API).
+
+Once the BLS signature is produced, it can be used to send a withdrawal command to the bridge contract on Ethereum. The bridge contract verifies the signature and other parameters, then **releases** the original tokens to the target Ethereum address.
+
+A similar BLS-signed flow is used to move native **GNK** to Ethereum as **WGNK**: GNK is locked on an escrow account on Gonka, a BLS signature is generated, and that signature is used to invoke a **mint** command on the bridge contract on Ethereum.
+
+### Same-key addressing
+
+For all flows above, the Gonka and Ethereum addresses are **derived from the same private/public key**. If you start from an existing Ethereum address holding USDT, generate the matching Gonka address from the same key — that Gonka address will receive the wrapped token. If you start from an existing Gonka address, generate the corresponding Ethereum address from the same key, fund it with USDT/ETH, and ensure you have enough ETH for gas.
+
+## How IBC USDT transfers work
+
+IBC USDT is a **different asset class** from the wrapped tokens above. It arrives on Gonka via the Cosmos IBC channel from Kava (channel-5 on the Gonka side, channel-161 on the Kava side at the time this guide was written). It is **not** minted by the Gonka Ethereum bridge.
+
+To move IBC USDT out of Gonka, you use the Cosmos IBC path: Gonka → Kava Cosmos → Kava EVM → Ethereum (via Stargate). See [Withdraw IBC USDT via Kava](ibc-usdt-withdrawal.md) for the step-by-step procedure.

--- a/docs/cross-chain-transfers/wrap-erc20-tokens.md
+++ b/docs/cross-chain-transfers/wrap-erc20-tokens.md
@@ -1,0 +1,208 @@
+# Wrap ERC-20 tokens (USDT)
+
+This guide shows how to wrap an ERC-20 token (USDT in the example) from
+Ethereum to Gonka via the native Ethereum bridge, transfer the wrapped CW-20
+token on Gonka, and withdraw it back to Ethereum.
+
+!!! danger "Bridge not yet active"
+    The Gonka Ethereum bridge contract is **not yet deployed** on Ethereum
+    mainnet. The address shown as `<bridge-contract-address>` below is a
+    **placeholder**. The actual address will be published in
+    [Release announcements](../release-announcements.md) once the bridge is
+    activated.
+
+    **Do not send any funds** to the bridge contract until the launch is
+    officially announced. Funds sent before activation will be lost.
+
+    This guide is published as a preview so the community can review the
+    flow ahead of the launch. Commands and parameters are subject to change.
+
+!!! warning "IBC USDT is a different asset"
+    «IBC USDT» (the USDT held in the Gonka community pool, paid for some
+    proposals) is **not** the same as the wrapped CW-20 USDT produced by this
+    bridge. They have different denominations and different redemption routes.
+    To move IBC USDT, use [Withdraw IBC USDT via Kava](ibc-usdt-withdrawal.md)
+    instead.
+
+## Same-key addressing
+
+The Gonka and Ethereum addresses used by the bridge are derived from the
+**same private/public key**.
+
+- If you want to use an existing Ethereum address that already holds USDT,
+  generate the matching Gonka address from the same private key — that Gonka
+  address will receive the wrapped token.
+- If instead you want to use an existing Gonka address, generate the
+  corresponding Ethereum address from the same private key, acquire USDT on
+  it, and ensure you have enough ETH for gas.
+
+## A) Send USDT to the bridge contract on Ethereum
+
+Transfer USDT from your Ethereum address to the bridge contract. Any standard
+ERC-20 `transfer` call works; the example below uses ethers.js:
+
+```javascript
+const tx = await usdtContract.transfer(
+  "<bridge-contract-address>",   // bridge address (placeholder)
+  amountBN                       // BigNumber amount
+);
+await tx.wait();
+```
+
+Once the transaction is confirmed on Ethereum and recognized by Gonka
+consensus, the bridge mints wrapped CW-20 USDT on Gonka. Ownership is
+assigned to the Gonka address derived from the same key as the sending
+Ethereum address.
+
+## B) Check wrapped token balance on Gonka
+
+Query the wrapped tokens owned by a Gonka address via the API:
+
+```bash
+curl "https://node2.gonka.ai:8433/chain-api/productscience/inference/inference/wrapped_token_balances/{gonkaAddress}"
+```
+
+Example response:
+
+```json
+{
+  "balances": [
+    {
+      "token_info": {
+        "chainId": "ethereum",
+        "contractAddress": "0xUSDTContractAddress",
+        "wrappedContractAddress": "gonka1CW20WrappedUSDTAddress"
+      },
+      "symbol": "USDT",
+      "balance": "100000",
+      "decimals": "6",
+      "formatted_balance": "0.1"
+    }
+  ]
+}
+```
+
+The `wrappedContractAddress` is the CW-20 address of the wrapped USDT on
+Gonka. You'll use it in the next steps.
+
+## C) Transfer wrapped USDT on Gonka
+
+Use the wrapped CW-20 address returned above to transfer to any Gonka
+account:
+
+```bash
+export WUSDT_CONTRACT="gonka1CW20WrappedUSDTAddress"
+
+./inferenced tx wasm execute $WUSDT_CONTRACT \
+  '{"transfer":{"recipient":"gonka1xxxxxxxx...","amount":"123456"}}' \
+  --from <your_key_name> --chain-id gonka-mainnet --gas auto
+```
+
+Example output:
+
+```
+...
+txhash: 39E3D4B86CF6B0C8952C789F4D73DB9FE27DEA4BD25F3842BE9298C78980A51D
+```
+
+Wait 2-3 blocks, then check the transaction status:
+
+```bash
+./inferenced query tx 39E3D4B86CF6B0C8952C789F4D73DB9FE27DEA4BD25F3842BE9298C78980A51D
+```
+
+`"code": 0` means the transfer was successful.
+
+!!! note "Gas estimation"
+    `--gas auto` may produce an incorrect gas estimate. If the transaction
+    fails for that reason, the transaction status will show the required gas
+    amount; rerun the command with an explicit `--gas` value (for example
+    `--gas 200000`).
+
+## D) Withdraw wrapped USDT back to Ethereum
+
+Submit a withdrawal request on Gonka, which burns the wrapped USDT and
+triggers BLS signature generation:
+
+```bash
+./inferenced tx wasm execute <gonka1CW20WrappedUSDTAddress> \
+  '{"withdraw":{"amount":"<amount>","destination_address":"0xYourEthereumAddr"}}' \
+  --from <your_key_name> \
+  --chain-id gonka-mainnet \
+  --gas auto \
+  -y \
+  --node http://node2.gonka.ai:8000/chain-rpc/
+```
+
+Expected output:
+
+```
+...
+txhash: 12E8ABCA5A35D73042564FDF6D686424F742414EEC172450AB6EDA34BD1F0805
+```
+
+Wait a couple of blocks and check the transaction:
+
+```bash
+./inferenced query tx 12E8ABCA5A35D73042564FDF6D686424F742414EEC172450AB6EDA34BD1F0805
+```
+
+The result contains:
+
+- `"code": 0` — success
+- `request_id: "vSTWiN1pvooxcFoDLzePCEq3x/C5NQ+jFMvfcEozCm4="` — the request
+  ID for the next step (base64-encoded)
+
+Convert the request ID to hex (you'll need it for the BLS lookup and the
+Ethereum withdrawal command):
+
+```bash
+echo "vSTWiN1pvooxcFoDLzePCEq3x/C5NQ+jFMvfcEozCm4=" | base64 -d | xxd -p -c 256
+# bd24d688dd69be8a31705a032f378f084ab7c7f0b9350fa314cbdf704a330a6e
+```
+
+!!! note "Gas estimation"
+    `--gas auto` may produce an incorrect gas estimate. If the transaction
+    fails, rerun with an explicit `--gas` value (for example `--gas 200000`).
+
+## E) Get BLS signature status
+
+Poll the BLS signature endpoint with the hex request ID until the signature
+is available:
+
+```bash
+curl "https://node2.gonka.ai:8433/v1/bls/signatures/<REQUEST_ID_HEX>" \
+  | jq -r '
+    {
+      uncompressed_signature_128: .uncompressed_signature_128,
+      current_epoch_id: .signing_request.current_epoch_id,
+      request_id: .signing_request.request_id
+    }
+  '
+```
+
+The response includes:
+
+- `current_epoch_id` — epoch of the request
+- `request_id` — 32-byte hash used on Gonka
+- `uncompressed_signature_128` — the BLS signature you'll submit to the
+  bridge contract on Ethereum
+
+## F) Submit withdrawal command on Ethereum
+
+Use the [`withdraw-tokens.js`](https://github.com/gonka-ai/gonka/blob/gm/contracts/proposals/ethereum-bridge-contact/withdraw-tokens.js)
+script to invoke the bridge contract on Ethereum with the BLS signature:
+
+```bash
+HARDHAT_NETWORK=mainnet node withdraw-tokens.js \
+  <bridge-contract-address> \
+  <current_epoch_id> \
+  <request_id> \
+  <destination_address> \
+  <USDT_contract_address> \
+  <amount> \
+  <uncompressed_signature_128>
+```
+
+The bridge contract verifies the signature and parameters, then releases the
+original USDT to `<destination_address>` on Ethereum.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,6 +39,15 @@ nav:
     - Dashboard: wallet/dashboard.md
     - Pricing: wallet/pricing.md
 
+  - Cross-Chain Transfers:
+    - Overview: cross-chain-transfers/index.md
+    - Ethereum bridge:
+      - Wrap ERC-20 tokens (USDT): cross-chain-transfers/wrap-erc20-tokens.md
+      - Move GNK to Ethereum (WGNK): cross-chain-transfers/gnk-to-ethereum.md
+      - Move ETH to Gonka (WETH): cross-chain-transfers/eth-to-gonka.md
+    - IBC transfers:
+      - Withdraw IBC USDT via Kava: cross-chain-transfers/ibc-usdt-withdrawal.md
+
   - Reference:
     - Transactions & governance: transactions-and-governance.md
     - Software upgrades: software-upgrades.md
@@ -165,6 +174,14 @@ plugins:
             Wallet & transfer guide: 钱包与转账指南
             Dashboard: 仪表盘
             Pricing: 价格
+            Cross-Chain Transfers: 跨链转账
+            Overview: 概览
+            Ethereum bridge: 以太坊跨链桥
+            "Wrap ERC-20 tokens (USDT)": 包装 ERC-20 代币 (USDT)
+            "Move GNK to Ethereum (WGNK)": GNK 转至以太坊 (WGNK)
+            "Move ETH to Gonka (WETH)": ETH 转至 Gonka (WETH)
+            IBC transfers: IBC 转账
+            Withdraw IBC USDT via Kava: 通过 Kava 提取 IBC USDT
             Reference: 参考
             Transactions & governance: 交易与治理
             Software upgrades: 软件升级


### PR DESCRIPTION
New top-level "Cross-Chain Transfers" section in the nav covering two independent transfer mechanisms:

- Overview (cross-chain-transfers/index.md) — status of each mechanism, router table mapping "what you have / what you want" to the right guide, disambiguation between IBC USDT and bridge-wrapped USDT (different assets, different routes), and a concept summary of how the Ethereum bridge works (lock & mint, BLS-signed withdrawals, same-key addressing).

- Ethereum bridge (preview — contract NOT yet deployed):
  - Wrap ERC-20 tokens (USDT) — full flow A-F: deposit, balance check, CW-20 transfer, withdrawal request, BLS signature lookup, and final withdraw-tokens.js call on Ethereum.
  - Move GNK to Ethereum (WGNK) — flow A-C: request-bridge-mint on Gonka, BLS signature lookup, and mint-wgnk.js call on Ethereum.
  - Move ETH to Gonka (WETH) — stub with concept + same-key addressing
    + placeholder for the launch-time commands.

  Every Ethereum bridge page carries a prominent !!! danger admonition
  warning that the bridge contract is not yet deployed, that
  <bridge-contract-address> is a placeholder, and that funds sent before
  activation will be lost.

- IBC transfers (live today):
  - Withdraw IBC USDT via Kava — full step-by-step route Gonka -> Kava Cosmos -> Kava EVM -> Ethereum (Stargate), including Keplr/MetaMask setup, test-first guidance, and the advanced channel-verification curl.

Also updates Chinese nav_translations for the new keys.

multisig_participant_guide.md is intentionally not added to the nav.