### PR TITLE
docs: fix gas flags after v0.2.12 fee enforcement

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -495,7 +495,7 @@ To vote, you can use the command below. This example votes yes, but you can repl
       --from <cold_key_name> \
       --keyring-backend file \
       --unordered \
-      --timeout-duration=60s --gas=2000000 --gas-adjustment=5.0 \
+      --timeout-duration=60s --gas=auto --gas-adjustment=1.3 --gas-prices=10ngonka \
       --node $NODE_URL/chain-rpc/ \
       --chain-id gonka-mainnet \
       --yes
@@ -538,7 +538,7 @@ export NODE_URL=http://<NODE_URL>:<port>
     --chain-id gonka-mainnet \
     --gas auto \
     --gas-adjustment 1.5 \
-    --fees 200000ngonka \
+    --gas-prices 10ngonka \
     --node $NODE_URL/chain-rpc/
 ```
 Then, to check if the node was unjailed:
@@ -964,6 +964,7 @@ Back up the **cold key** on your local device, outside the server.
         --from gonka-account-key \
         --keyring-backend file \
         --gas 2000000 \
+        --gas-prices 10ngonka \
         --node http://<node-url>/chain-rpc/
     ```
 

--- a/docs/host/kimi-bootstrap.md
+++ b/docs/host/kimi-bootstrap.md
@@ -59,7 +59,8 @@ export NODE=https://node3.gonka.ai/
   --keyring-backend file \
   --gas auto \
   --gas-adjustment 1.3 \
-  -y \
+  --gas-prices 10ngonka \
+  -y
 ```
 
 #### 2. Check your setup and make sure the `Kimi-K2.6` weights are downloaded and you can deploy the model successfully
@@ -162,6 +163,7 @@ export NODE=https://node3.gonka.ai/chain-rpc/
   --keyring-backend file \
   --gas auto \
   --gas-adjustment 1.3 \
+  --gas-prices 10ngonka \
   -y
 ```
 
@@ -175,5 +177,6 @@ export NODE=https://node3.gonka.ai/chain-rpc/
   --keyring-backend file \
   --gas auto \
   --gas-adjustment 1.3 \
+  --gas-prices 10ngonka \
   -y
 ```

--- a/docs/host/multi_model_poc.md
+++ b/docs/host/multi_model_poc.md
@@ -244,6 +244,7 @@ DELEGATEE="gonka1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
   --keyring-backend "$KEYRING_BACKEND" \
   --gas auto \
   --gas-adjustment 1.3 \
+  --gas-prices 10ngonka \
   -y
 ```
 
@@ -259,6 +260,7 @@ MODEL="your-model-id"
   --keyring-backend "$KEYRING_BACKEND" \
   --gas auto \
   --gas-adjustment 1.3 \
+  --gas-prices 10ngonka \
   -y
 ```
 
@@ -274,6 +276,7 @@ MODEL="your-model-id"
   --keyring-backend "$KEYRING_BACKEND" \
   --gas auto \
   --gas-adjustment 1.3 \
+  --gas-prices 10ngonka \
   -y
 ```
 
@@ -289,6 +292,7 @@ MODEL="your-model-id"
   --keyring-backend "$KEYRING_BACKEND" \
   --gas auto \
   --gas-adjustment 1.3 \
+  --gas-prices 10ngonka \
   -y
 ```
 

--- a/docs/host/quickstart.md
+++ b/docs/host/quickstart.md
@@ -766,6 +766,7 @@ Grant permissions from your Account Key to the ML Operational Key:
     --from gonka-account-key \
     --keyring-backend file \
     --gas 2000000 \
+    --gas-prices 10ngonka \
     --node <seed_api_url from server's config.env>/chain-rpc/ 
 ```
 
@@ -960,6 +961,7 @@ DELEGATEE="gonka1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
   --keyring-backend "$KEYRING_BACKEND" \
   --gas auto \
   --gas-adjustment 1.3 \
+  --gas-prices 10ngonka \
   -y
 ```
 
@@ -976,6 +978,7 @@ DELEGATEE="gonka1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
   --keyring-backend "$KEYRING_BACKEND" \
   --gas auto \
   --gas-adjustment 1.3 \
+  --gas-prices 10ngonka \
   -y
 ```
 
@@ -991,6 +994,7 @@ MODEL="moonshotai/Kimi-K2.6"
   --keyring-backend "$KEYRING_BACKEND" \
   --gas auto \
   --gas-adjustment 1.3 \
+  --gas-prices 10ngonka \
   -y
 ```
 
@@ -1006,6 +1010,7 @@ MODEL="moonshotai/Kimi-K2.6"
   --keyring-backend "$KEYRING_BACKEND" \
   --gas auto \
   --gas-adjustment 1.3 \
+  --gas-prices 10ngonka \
   -y
 ```
 

--- a/docs/release-announcements.md
+++ b/docs/release-announcements.md
@@ -220,7 +220,7 @@ export NODE_URL=https://node3.gonka.ai/
   --from <cold_key_name> \
   --keyring-backend file \
   --unordered \
-  --timeout-duration=60s --gas=2000000 --gas-adjustment=5.0 \
+  --timeout-duration=60s --gas=auto --gas-adjustment=1.3 --gas-prices=10ngonka \
   --node $NODE_URL/chain-rpc/ \
   --chain-id gonka-mainnet \
   --yes
@@ -483,7 +483,7 @@ export NODE_URL=https://node3.gonka.ai/
 --from <cold_key_name> \
 --keyring-backend file \
 --unordered \
---timeout-duration=60s --gas=2000000 --gas-adjustment=5.0 \
+--timeout-duration=60s --gas=auto --gas-adjustment=1.3 --gas-prices=10ngonka \
 --node $NODE_URL/chain-rpc/ \
 --chain-id gonka-mainnet \
 --yes
@@ -691,7 +691,7 @@ export NODE_URL=https://node3.gonka.ai/
 --from <cold_key_name> \
 --keyring-backend file \
 --unordered \
---timeout-duration=60s --gas=2000000 --gas-adjustment=5.0 \
+--timeout-duration=60s --gas=auto --gas-adjustment=1.3 --gas-prices=10ngonka \
 --node $NODE_URL/chain-rpc/ \
 --chain-id gonka-mainnet \
 --yes
@@ -1212,7 +1212,7 @@ export NODE_URL=https://node3.gonka.ai/
 --from <cold_key_name> \
 --keyring-backend file \
 --unordered \
---timeout-duration=60s --gas=2000000 --gas-adjustment=5.0 \
+--timeout-duration=60s --gas=auto --gas-adjustment=1.3 --gas-prices=10ngonka \
 --node $NODE_URL/chain-rpc/ \
 --chain-id gonka-mainnet \
 --yes
@@ -1281,7 +1281,7 @@ export NODE_URL=https://node3.gonka.ai/
 --from <cold_key_name> \
 --keyring-backend file \
 --unordered \
---timeout-duration=60s --gas=2000000 --gas-adjustment=5.0 \
+--timeout-duration=60s --gas=auto --gas-adjustment=1.3 --gas-prices=10ngonka \
 --node $NODE_URL/chain-rpc/ \
 --chain-id gonka-mainnet \
 --yes
@@ -1729,7 +1729,7 @@ export NODE_URL=https://node4.gonka.ai/
 --from <cold_key_name> \
 --keyring-backend file \
 --unordered \
---timeout-duration=60s --gas=2000000 --gas-adjustment=5.0 \
+--timeout-duration=60s --gas=auto --gas-adjustment=1.3 --gas-prices=10ngonka \
 --node $NODE_URL/chain-rpc/ \
 --chain-id gonka-mainnet \
 --yes
@@ -2091,7 +2091,7 @@ export NODE_URL=https://node4.gonka.ai/
 --from <cold_key_name> \
 --keyring-backend file \
 --unordered \
---timeout-duration=60s --gas=2000000 --gas-adjustment=5.0 \
+--timeout-duration=60s --gas=auto --gas-adjustment=1.3 --gas-prices=10ngonka \
 --node $NODE_URL/chain-rpc/ \
 --chain-id gonka-mainnet \
 --yes
@@ -2189,7 +2189,7 @@ export NODE_URL=http://node1.gonka.ai:8000
 --from <cold_key_name> \
 --keyring-backend file \
 --unordered \
---timeout-duration=60s --gas=2000000 --gas-adjustment=5.0 \
+--timeout-duration=60s --gas=auto --gas-adjustment=1.3 --gas-prices=10ngonka \
 --node $NODE_URL/chain-rpc/ \
 --chain-id gonka-mainnet \
 --yes
@@ -2241,7 +2241,7 @@ export NODE_URL=http://node1.gonka.ai:8000
 --from <cold_key_name> \
 --keyring-backend file \
 --unordered \
---timeout-duration=60s --gas=2000000 --gas-adjustment=5.0 \
+--timeout-duration=60s --gas=auto --gas-adjustment=1.3 --gas-prices=10ngonka \
 --node $NODE_URL/chain-rpc/ \
 --chain-id gonka-mainnet \
 --yes
@@ -2352,7 +2352,7 @@ export NODE_URL=http://node1.gonka.ai:8000
 --from <cold_key_name> \
 --keyring-backend file \
 --unordered \
---timeout-duration=60s --gas=2000000 --gas-adjustment=5.0 \
+--timeout-duration=60s --gas=auto --gas-adjustment=1.3 --gas-prices=10ngonka \
 --node $NODE_URL/chain-rpc/ \
 --chain-id gonka-mainnet \
 --yes
@@ -2604,7 +2604,7 @@ export NODE_URL=http://node1.gonka.ai:8000
 --from <cold_key_name> \
 --keyring-backend file \
 --unordered \
---timeout-duration=60s --gas=2000000 --gas-adjustment=5.0 \
+--timeout-duration=60s --gas=auto --gas-adjustment=1.3 --gas-prices=10ngonka \
 --node $NODE_URL/chain-rpc/ \
 --chain-id gonka-mainnet \
 --yes

--- a/docs/transactions-and-governance.md
+++ b/docs/transactions-and-governance.md
@@ -9,7 +9,7 @@ Unordered transactions are supported and recommended here to avoid sequence cont
 - `--from <cold-key-name>` → use your cold governance key.
 - `--keyring-backend file` → ensures signing with your local key (you will be prompted).
 - `--unordered --timeout-duration=60s` → makes the tx valid for a bounded time, bypassing sequence ordering (new in v0.53+).
-- `--gas=2000000 --gas-adjustment=5.0` → manual gas setting with buffer.
+- `--gas=auto --gas-adjustment=1.3 --gas-prices=10ngonka` → simulate gas with a 30% buffer and pay at the chain's minimum gas price (`FeeParams.min_gas_price_ngonka` defaults to `10ngonka` after v0.2.12; using `--gas-prices` instead of `--fees` keeps the fee proportional to simulated gas and survives a future governance bump of the min price).
 - `--node $SEED_URL/chain-rpc/` → required unless you run a local RPC node.
 - `--yes` → auto-approve broadcasting.
 
@@ -68,7 +68,7 @@ inferenced tx gov vote <proposal_id> yes \
   --from <cold-key-name> \
   --keyring-backend file \
   --unordered --timeout-duration=60s \
-  --gas=2000000 --gas-adjustment=5.0 \
+  --gas=auto --gas-adjustment=1.3 --gas-prices=10ngonka \
   --node $SEED_URL/chain-rpc/ \
   --yes
 ```
@@ -161,7 +161,7 @@ inferenced tx gov submit-proposal ./draft_proposal.json \
   --from <cold-key-name> \
   --keyring-backend file \
   --unordered --timeout-duration=60s \
-  --gas=2000000 --gas-adjustment=5.0 \
+  --gas=auto --gas-adjustment=1.3 --gas-prices=10ngonka \
   --node $SEED_URL/chain-rpc/ \
   --yes
 ```
@@ -187,7 +187,7 @@ inferenced tx gov deposit <proposal_id> <amount> \
   --from <cold-key-name> \
   --keyring-backend file \
   --unordered --timeout-duration=60s \
-  --gas=2000000 --gas-adjustment=5.0 \
+  --gas=auto --gas-adjustment=1.3 --gas-prices=10ngonka \
   --node $SEED_URL/chain-rpc/ \
   --yes
 ```
@@ -204,7 +204,7 @@ inferenced tx gov vote <proposal_id> yes \
   --from <cold-key-name> \
   --keyring-backend file \
   --unordered --timeout-duration=60s \
-  --gas=2000000 --gas-adjustment=5.0 \
+  --gas=auto --gas-adjustment=1.3 --gas-prices=10ngonka \
   --node $SEED_URL/chain-rpc/ \
   --yes
 ```

--- a/docs/zh/FAQ.md
+++ b/docs/zh/FAQ.md
@@ -495,7 +495,7 @@ Base Weight +
       --from <cold_key_name> \
       --keyring-backend file \
       --unordered \
-      --timeout-duration=60s --gas=2000000 --gas-adjustment=5.0 \
+      --timeout-duration=60s --gas=auto --gas-adjustment=1.3 --gas-prices=10ngonka \
       --node $NODE_URL/chain-rpc/ \
       --chain-id gonka-mainnet \
       --yes
@@ -538,7 +538,7 @@ export NODE_URL=http://<NODE_URL>:<port>
     --chain-id gonka-mainnet \
     --gas auto \
     --gas-adjustment 1.5 \
-    --fees 200000ngonka \
+    --gas-prices 10ngonka \
     --node $NODE_URL/chain-rpc/
 ```
 然后，检查节点是否已解除监禁：
@@ -965,6 +965,7 @@ v0.2.8 升级完成后，PoC v2 的逻辑已可用，但**尚未用于权重分�
         --from gonka-account-key \
         --keyring-backend file \
         --gas 2000000 \
+        --gas-prices 10ngonka \
         --node http://<node-url>/chain-rpc/
     ```
 

--- a/docs/zh/host/quickstart.md
+++ b/docs/zh/host/quickstart.md
@@ -754,6 +754,7 @@ exit
     --from gonka-account-key \
     --keyring-backend file \
     --gas 2000000 \
+    --gas-prices 10ngonka \
     --node <服务器 config.env 中的 seed_api_url>/chain-rpc/ 
 ```
 
@@ -948,6 +949,7 @@ DELEGATEE="gonka1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
   --keyring-backend "$KEYRING_BACKEND" \
   --gas auto \
   --gas-adjustment 1.3 \
+  --gas-prices 10ngonka \
   -y
 ```
 
@@ -964,6 +966,7 @@ DELEGATEE="gonka1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
   --keyring-backend "$KEYRING_BACKEND" \
   --gas auto \
   --gas-adjustment 1.3 \
+  --gas-prices 10ngonka \
   -y
 ```
 
@@ -979,6 +982,7 @@ MODEL="moonshotai/Kimi-K2.6"
   --keyring-backend "$KEYRING_BACKEND" \
   --gas auto \
   --gas-adjustment 1.3 \
+  --gas-prices 10ngonka \
   -y
 ```
 
@@ -994,6 +998,7 @@ MODEL="moonshotai/Kimi-K2.6"
   --keyring-backend "$KEYRING_BACKEND" \
   --gas auto \
   --gas-adjustment 1.3 \
+  --gas-prices 10ngonka \
   -y
 ```
 

--- a/docs/zh/release-announcements.md
+++ b/docs/zh/release-announcements.md
@@ -221,7 +221,7 @@ export NODE_URL=https://node3.gonka.ai/
   --from <cold_key_name> \
   --keyring-backend file \
   --unordered \
-  --timeout-duration=60s --gas=2000000 --gas-adjustment=5.0 \
+  --timeout-duration=60s --gas=auto --gas-adjustment=1.3 --gas-prices=10ngonka \
   --node $NODE_URL/chain-rpc/ \
   --chain-id gonka-mainnet \
   --yes
@@ -486,7 +486,7 @@ export NODE_URL=https://node3.gonka.ai/
 --from <cold_key_name> \
 --keyring-backend file \
 --unordered \
---timeout-duration=60s --gas=2000000 --gas-adjustment=5.0 \
+--timeout-duration=60s --gas=auto --gas-adjustment=1.3 --gas-prices=10ngonka \
 --node $NODE_URL/chain-rpc/ \
 --chain-id gonka-mainnet \
 --yes
@@ -694,7 +694,7 @@ export NODE_URL=https://node3.gonka.ai/
 --from <cold_key_name> \
 --keyring-backend file \
 --unordered \
---timeout-duration=60s --gas=2000000 --gas-adjustment=5.0 \
+--timeout-duration=60s --gas=auto --gas-adjustment=1.3 --gas-prices=10ngonka \
 --node $NODE_URL/chain-rpc/ \
 --chain-id gonka-mainnet \
 --yes
@@ -1229,7 +1229,7 @@ export NODE_URL=https://node3.gonka.ai/
 --from <cold_key_name> \
 --keyring-backend file \
 --unordered \
---timeout-duration=60s --gas=2000000 --gas-adjustment=5.0 \
+--timeout-duration=60s --gas=auto --gas-adjustment=1.3 --gas-prices=10ngonka \
 --node $NODE_URL/chain-rpc/ \
 --chain-id gonka-mainnet \
 --yes
@@ -1304,7 +1304,7 @@ export NODE_URL=https://node3.gonka.ai/
 --from <cold_key_name> \
 --keyring-backend file \
 --unordered \
---timeout-duration=60s --gas=2000000 --gas-adjustment=5.0 \
+--timeout-duration=60s --gas=auto --gas-adjustment=1.3 --gas-prices=10ngonka \
 --node $NODE_URL/chain-rpc/ \
 --chain-id gonka-mainnet \
 --yes
@@ -1758,7 +1758,7 @@ export NODE_URL=https://node4.gonka.ai/
 --from <cold_key_name> \
 --keyring-backend file \
 --unordered \
---timeout-duration=60s --gas=2000000 --gas-adjustment=5.0 \
+--timeout-duration=60s --gas=auto --gas-adjustment=1.3 --gas-prices=10ngonka \
 --node $NODE_URL/chain-rpc/ \
 --chain-id gonka-mainnet \
 --yes
@@ -2120,7 +2120,7 @@ export NODE_URL=https://node4.gonka.ai/
 --from <cold_key_name> \
 --keyring-backend file \
 --unordered \
---timeout-duration=60s --gas=2000000 --gas-adjustment=5.0 \
+--timeout-duration=60s --gas=auto --gas-adjustment=1.3 --gas-prices=10ngonka \
 --node $NODE_URL/chain-rpc/ \
 --chain-id gonka-mainnet \
 --yes
@@ -2218,7 +2218,7 @@ export NODE_URL=http://node1.gonka.ai:8000
 --from <cold_key_name> \
 --keyring-backend file \
 --unordered \
---timeout-duration=60s --gas=2000000 --gas-adjustment=5.0 \
+--timeout-duration=60s --gas=auto --gas-adjustment=1.3 --gas-prices=10ngonka \
 --node $NODE_URL/chain-rpc/ \
 --chain-id gonka-mainnet \
 --yes
@@ -2270,7 +2270,7 @@ export NODE_URL=http://node1.gonka.ai:8000
 --from <cold_key_name> \
 --keyring-backend file \
 --unordered \
---timeout-duration=60s --gas=2000000 --gas-adjustment=5.0 \
+--timeout-duration=60s --gas=auto --gas-adjustment=1.3 --gas-prices=10ngonka \
 --node $NODE_URL/chain-rpc/ \
 --chain-id gonka-mainnet \
 --yes
@@ -2381,7 +2381,7 @@ export NODE_URL=http://node1.gonka.ai:8000
 --from <cold_key_name> \
 --keyring-backend file \
 --unordered \
---timeout-duration=60s --gas=2000000 --gas-adjustment=5.0 \
+--timeout-duration=60s --gas=auto --gas-adjustment=1.3 --gas-prices=10ngonka \
 --node $NODE_URL/chain-rpc/ \
 --chain-id gonka-mainnet \
 --yes
@@ -2633,7 +2633,7 @@ export NODE_URL=http://node1.gonka.ai:8000
 --from <cold_key_name> \
 --keyring-backend file \
 --unordered \
---timeout-duration=60s --gas=2000000 --gas-adjustment=5.0 \
+--timeout-duration=60s --gas=auto --gas-adjustment=1.3 --gas-prices=10ngonka \
 --node $NODE_URL/chain-rpc/ \
 --chain-id gonka-mainnet \
 --yes

--- a/docs/zh/transactions-and-governance.md
+++ b/docs/zh/transactions-and-governance.md
@@ -9,7 +9,7 @@
 - `--from <cold-key-name>` → 使用你的冷治理密钥。
 - `--keyring-backend file` → 确保使用本地密钥签名（系统会提示你）。
 - `--unordered --timeout-duration=60s` → 使交易在有限时间内有效，绕过序列排序（v0.53+ 新增）。
-- `--gas=2000000 --gas-adjustment=5.0` → 带缓冲的手动 gas 设置。
+- `--gas=auto --gas-adjustment=1.3 --gas-prices=10ngonka` → 通过模拟自动估算 gas 并加 30% 缓冲，按链上最小 gas 价格支付（v0.2.12 起 `FeeParams.min_gas_price_ngonka` 默认值为 `10ngonka`；使用 `--gas-prices` 而非 `--fees` 可让 fee 与模拟出的 gas 成比例，并在 governance 调整 min price 时仍然有效）。
 - `--node $SEED_URL/chain-rpc/` → 除非你运行本地 RPC 节点，否则必需。
 - `--yes` → 自动批准广播。
 
@@ -68,7 +68,7 @@ inferenced tx gov vote <proposal_id> yes \
   --from <cold-key-name> \
   --keyring-backend file \
   --unordered --timeout-duration=60s \
-  --gas=2000000 --gas-adjustment=5.0 \
+  --gas=auto --gas-adjustment=1.3 --gas-prices=10ngonka \
   --node $SEED_URL/chain-rpc/ \
   --yes
 ```
@@ -161,7 +161,7 @@ inferenced tx gov submit-proposal ./draft_proposal.json \
   --from <cold-key-name> \
   --keyring-backend file \
   --unordered --timeout-duration=60s \
-  --gas=2000000 --gas-adjustment=5.0 \
+  --gas=auto --gas-adjustment=1.3 --gas-prices=10ngonka \
   --node $SEED_URL/chain-rpc/ \
   --yes
 ```
@@ -187,7 +187,7 @@ inferenced tx gov deposit <proposal_id> <amount> \
   --from <cold-key-name> \
   --keyring-backend file \
   --unordered --timeout-duration=60s \
-  --gas=2000000 --gas-adjustment=5.0 \
+  --gas=auto --gas-adjustment=1.3 --gas-prices=10ngonka \
   --node $SEED_URL/chain-rpc/ \
   --yes
 ```
@@ -204,7 +204,7 @@ inferenced tx gov vote <proposal_id> yes \
   --from <cold-key-name> \
   --keyring-backend file \
   --unordered --timeout-duration=60s \
-  --gas=2000000 --gas-adjustment=5.0 \
+  --gas=auto --gas-adjustment=1.3 --gas-prices=10ngonka \
   --node $SEED_URL/chain-rpc/ \
   --yes
 ```


### PR DESCRIPTION
## Summary

`v0.2.12` ships a consensus-level `GonkaFeeChecker` driven by `FeeParams.min_gas_price_ngonka`. The shipped value is `0` (fees temporarily disabled per `proposals/governance-artifacts/update-v0.2.12/README.md`), but the in-code default and `proposals/transaction-fees/README.md` both target `10ngonka`, and governance can flip the value at any time without a chain upgrade. The example commands across the docs were not forward-safe, and several were already incorrect today.

This PR fixes three classes of bugs and one cosmetic issue across 10 markdown files (English + Chinese).

### 1. `--gas=2000000 --gas-adjustment=5.0` → `--gas=auto --gas-adjustment=1.3 --gas-prices=10ngonka`

The previous form is inconsistent with the Cosmos SDK CLI: when `--gas` is a fixed integer, `--gas-adjustment` is a no-op and the documented "manual gas setting with buffer" never actually adds a buffer.

Affected files:
- `docs/transactions-and-governance.md` (5 occurrences incl. the description line at the top)
- `docs/release-announcements.md` (11 occurrences)
- `docs/FAQ.md` (1 occurrence in the gov-vote example)
- `docs/zh/` mirrors of all of the above

### 2. `tx slashing unjail` — `--fees 200000ngonka` → `--gas-prices 10ngonka`

`docs/FAQ.md` (and `docs/zh/FAQ.md`) "How to Unjail Your Node":

```diff
   --gas auto \
   --gas-adjustment 1.5 \
-  --fees 200000ngonka \
+  --gas-prices 10ngonka \
```

`--fees` is a fixed amount that does not scale with `--gas auto`. As soon as governance enables `min_gas_price_ngonka > 0`, the `200000ngonka` fee will be rejected by `GonkaFeeChecker` (`inference-chain/app/ante_fee.go:201`) once simulated gas grows past ~20k. `--gas-prices` is the only forward-safe pattern.

### 3. Add `--gas-prices 10ngonka` to host-guide commands that are not in the bypass list

`NetworkDutyFeeBypassDecorator` exempts only the protocol-duty messages (PoC submissions, validation messages, BLS DKG rounds, inference start/finish/invalidate/revalidate — see `inference-chain/app/ante_fee.go:114-152`). The following commands documented in the host guides are NOT in that list and will start failing the moment governance turns fees on:

- `tx inference grant-ml-ops-permissions` (`docs/host/quickstart.md`, `docs/FAQ.md`)
- `tx inference set-poc-delegation`, `refuse-poc-delegation`, `declare-poc-intent` (`docs/host/quickstart.md`, `docs/host/multi_model_poc.md`, `docs/host/kimi-bootstrap.md`)

All these blocks now carry `--gas-prices 10ngonka`. Today (with `min_gas_price_ngonka == 0`) there is no overpayment because fee = `gas × gas-prices` is calculated by the actual values; the change is purely forward-safety.

### 4. Cosmetic: stray trailing backslash in `kimi-bootstrap.md`

The first `declare-poc-intent` block ended with `-y \`, which would make a copy-pasted shell wait for additional input. Removed.

## Why `10ngonka`?

Matches `DefaultFeeParams().MinGasPriceNgonka` in `inference-chain/x/inference/types/fee_params.go` and the recommended initial value documented in `proposals/transaction-fees/README.md` §4.4. Once governance flips fees on, this is the value they will land on.

## Test plan

- [x] `rg --pcre2 -n '\-\-gas=2000000 \-\-gas-adjustment=5\.0' docs/` → no matches
- [x] `rg -n '\-\-fees ' docs/` → only descriptive text in `transactions-and-governance.md` (explaining why we don't use `--fees`); no actual command uses it
- [x] All `inferenced tx ...` blocks for non-exempt messages now include `--gas-prices 10ngonka`
- [x] No trailing `\` after `-y` anywhere
- [ ] Build the docs site (`mkdocs serve`) and visually verify the rendered code blocks
- [ ] Confirm with mainnet ops that `10ngonka` is the value governance is planning to enable (matches code default and the transaction-fees proposal, but worth a sanity check)

## Files changed

10 files, +56 / −37

Made with [Cursor](https://cursor.com)