### PR TITLE
docs: clarify quickstart Python output and tighten Go examples

### DIFF
--- a/docs/developer/quickstart.md
+++ b/docs/developer/quickstart.md
@@ -570,6 +570,7 @@ Define functions, and the model will return structured call arguments when the u
         call = message.tool_calls[0]
         args = json.loads(call.function.arguments)
         # model chose get_weather with {"city": "Paris"} — call your function now
+        print("TOOL CALL:")
         print(call.function.name, args)
     ```
 

--- a/docs/developer/quickstart.md
+++ b/docs/developer/quickstart.md
@@ -406,6 +406,7 @@ curl -s "$NODE_URL/v2/accounts/$GONKA_ADDRESS" | jq .
         ],
     )
 
+    print("RESPONSE:")
     print(response.choices[0].message.content)
     ```
 
@@ -472,7 +473,9 @@ curl -s "$NODE_URL/v2/accounts/$GONKA_ADDRESS" | jq .
         }
         defer resp.Body.Close()
         var ident struct {
-            Data struct{ Address string } `json:"data"`
+            Data struct {
+                Address string `json:"address"`
+            } `json:"data"`
         }
         if err := json.NewDecoder(resp.Body).Decode(&ident); err != nil {
             log.Fatal(err)
@@ -640,7 +643,9 @@ Define functions, and the model will return structured call arguments when the u
         }
         defer resp.Body.Close()
         var ident struct {
-            Data struct{ Address string } `json:"data"`
+            Data struct {
+                Address string `json:"address"`
+            } `json:"data"`
         }
         if err := json.NewDecoder(resp.Body).Decode(&ident); err != nil {
             log.Fatal(err)


### PR DESCRIPTION
## Summary
- add a clear `RESPONSE:` marker to the Python quickstart example output
- make the Go quickstart examples use explicit `json:"address"` decoding for `/v1/identity`

## Validation
- extracted the Go snippets from `docs/developer/quickstart.md`
- ran `go mod tidy`
- ran `go run example.go`
- ran `go run tool_calling.go`

Both Go examples ran successfully against the public gateway with a funded test account.