### PR TITLE
Add Dashboard maintainer memo v0.2.13 to Reference nav

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,7 @@ nav:
     - Transactions & governance: transactions-and-governance.md
     - Software upgrades: software-upgrades.md
     - Model licenses: model-licenses.md
+    - Dashboard maintainer memo v0.2.13: dashboard-maintainer-memo-v0.2.13.md
     - Errors: Errors.md
 
   - Resources:
@@ -169,6 +170,7 @@ plugins:
             Transactions & governance: 交易与治理
             Software upgrades: 软件升级
             "Model licenses": 模型许可
+            Dashboard maintainer memo v0.2.13: 仪表盘维护者备忘录 v0.2.13
             Errors: 错误
             Resources: 资源
             Release announcements: 发布公告


### PR DESCRIPTION
## Summary
- Adds the existing `docs/dashboard-maintainer-memo-v0.2.13.md` page to the **Reference** section of the left sidebar in `mkdocs.yml`.
- Adds the corresponding Chinese title translation under the i18n `nav_translations` block.

## Test plan
- [ ] Build the docs locally (`mkdocs serve` or via `buildtools/prepare-stages.sh`) and verify the new entry appears in the left nav under **Reference** in both English and Chinese.
- [ ] Confirm the link opens the existing `dashboard-maintainer-memo-v0.2.13.md` page.

Made with [Cursor](https://cursor.com)