### PR TITLE
docs(en): update host hardware specifications

### DIFF
--- a/docs/host/hardware-specifications.md
+++ b/docs/host/hardware-specifications.md
@@ -1,16 +1,12 @@
 # Hardware Specifications
 
-Criteria: Supports NVIDIA GPUs of generations newer than Tesla, provided that at least 40 GB total GPU VRAM is available to each MLNode container. Any combination of GPUs is allowed, as long as the system can host the LLMs approved by network governance and participate in PoC.
+Criteria: Supports NVIDIA GPUs of generations newer than Tesla, provided that at least 320 GB total GPU VRAM is available to each MLNode container. Any combination of GPUs is allowed, as long as the system can host the LLMs approved by network governance and participate in PoC.
 
-| NVIDIA GPU         | Release Date  | VRAM           | Architecture | Generation            |
-|---------------------|---------------|----------------|--------------|-----------------------|
-| H200               | 2024           | 141 GB of HBM3e| Hopper       | H100 (Data Center)   |
-| H100               | May 2022       | 80 GB HBM3     | Hopper       | H100 (Data Center)   |
-| A100               | May 2020       | 40 GB or 80 GB HBM2e | Ampere | A100                |
-| RTX 6000 Ada Gen   | December 2022  | 48 GB GDDR6    | Ada Lovelace | RTX 40 Series        |
-| RTX A6000          | December 2020  | 48 GB GDDR6    | Ampere       | RTX 30 Series        |
-| L40                | 2022           | 48 GB GDDR6    | Ada Lovelace | L-Series (Data Center) |
-| A40                | 2021           | 48 GB GDDR6    | Ampere       | A40                 |
-| RTX 4090 (>= 2 per MLNode)          | October 2022   | 24 GB GDDR6X   | Ada Lovelace | RTX 40 Series        |
-| RTX 3090 (>= 2 per MLNode)             | September 2020 | 24 GB GDDR6X   | Ampere       | RTX 30 Series        |
-| L4 (>= 2 per MLNode)                | March 2023     | 24 GB GDDR6    | Ada Lovelace | L-Series (Data Center) |
+| NVIDIA GPU | Release Date | VRAM | Architecture |
+|------------|--------------|------|--------------|
+| B300 | March 2025 | 288 GB HBM3e | Blackwell Ultra |
+| B200 | 2024 | 192 GB HBM3e | Blackwell |
+| RTX PRO 6000 | March 2025 | 96 GB GDDR7 ECC | Blackwell |
+| H200 | 2024 | 141 GB HBM3e | Hopper |
+| H100 | May 2022 | 80 GB HBM3 | Hopper |
+| A100 80GB | November 2020 | 80 GB HBM2e | Ampere |

--- a/docs/zh/host/hardware-specifications.md
+++ b/docs/zh/host/hardware-specifications.md
@@ -1,19 +1,15 @@
 技术标准：
 
-· GPU 要求： 须采用 NVIDIA Tesla 架构之后的 GPU 系列，且每个 MLNode 节点的可用 GPU 显存总量须 ≥ 40 GB。
+· GPU 要求： 须采用 NVIDIA Tesla 架构之后的 GPU 系列，且每个 MLNode 节点的可用 GPU 显存总量须 ≥ 320 GB。
 · 组合规则： 允许混搭不同型号的 GPU，但前提是整套系统必须能够稳定运行经网络管理委员会批准的大语言模型，并参与概念验证。
 
-| NVIDIA GPU         | 发布日期  | VRAM           | 架构 | 世代            |
-|---------------------|-----------|----------------|------|-----------------|
-| H200               | 2024年    | 141 GB HBM3e   | Hopper       | H100 (数据中心)   |
-| H100               | 2022年5月 | 80 GB HBM3     | Hopper       | H100 (数据中心)   |
-| A100               | 2020年5月 | 40 GB 或 80 GB HBM2e | Ampere | A100                |
-| RTX 6000 Ada Gen   | 2022年12月| 48 GB GDDR6    | Ada Lovelace | RTX 40 系列        |
-| RTX A6000          | 2020年12月| 48 GB GDDR6    | Ampere       | RTX 30 系列        |
-| L40                | 2022年    | 48 GB GDDR6    | Ada Lovelace | L 系列 (数据中心) |
-| A40                | 2021年    | 48 GB GDDR6    | Ampere       | A40                 |
-| RTX 4090 (每个 MLNode >= 2)          | 2022年10月| 24 GB GDDR6X   | Ada Lovelace | RTX 40 系列        |
-| RTX 3090 (每个 MLNode >= 2)             | 2020年9月| 24 GB GDDR6X   | Ampere       | RTX 30 系列        |
-| L4 (每个 MLNode >= 2)                | 2023年3月| 24 GB GDDR6    | Ada Lovelace | L 系列 (数据中心) |
+| NVIDIA GPU | 发布日期 | VRAM | 架构 |
+|------------|----------|------|------|
+| B300 | 2025年3月 | 288 GB HBM3e | Blackwell Ultra |
+| B200 | 2024年 | 192 GB HBM3e | Blackwell |
+| RTX PRO 6000 | 2025年3月 | 96 GB GDDR7 ECC | Blackwell |
+| H200 | 2024年 | 141 GB HBM3e | Hopper |
+| H100 | 2022年5月 | 80 GB HBM3 | Hopper |
+| A100 80GB | 2020年11月 | 80 GB HBM2e | Ampere |
 
 （注：最终部署方案必须保证物理显存总量满足模型运行需求，并通过网络管理委员会的正式技术审核。）


### PR DESCRIPTION
- Raised minimum MLNode VRAM requirement from 40 GB to 320 GB.
- Updated supported GPU table to current hardware list.
- Removed outdated or unsupported GPU entries.