### PR TITLE
Fix GON-170 review: W_threshold, PoC_start math, intent script retries

### DIFF
--- a/docs/host/kimi-bootstrap.md
+++ b/docs/host/kimi-bootstrap.md
@@ -137,11 +137,21 @@ DELAY = 0.15
 
 def session():
     s = requests.Session()
-    s.mount("https://", HTTPAdapter(max_retries=Retry(total=5, backoff_factor=0.5)))
+    # Retry transient 5xx (node3 returns 503 for some poc_delegation lookups
+    # under load) so a single hiccup does not silently drop a participant
+    # from the result.
+    retry = Retry(
+        total=5,
+        backoff_factor=0.5,
+        status_forcelist=(502, 503, 504),
+        allowed_methods=("GET",),
+    )
+    s.mount("https://", HTTPAdapter(max_retries=retry))
     s.headers["Connection"] = "close"
     return s
 
 def weight(p):
+    # weight may be 0, missing, or literally null — all mean "no voting weight".
     return int(p.get("weight") or 0)
 
 def get_json(s, url):
@@ -157,6 +167,7 @@ participants = get_json(s, f"{NODE}/v1/epochs/current/participants")[
 
 intents = []
 with_kimi_model = []
+skipped = []  # participants whose poc_delegation lookup failed after retries
 
 for p in participants:
     addr = p["index"]
@@ -170,7 +181,7 @@ for p in participants:
             f"{NODE}/chain-api/productscience/inference/inference/poc_delegation/{addr}",
         )
     except requests.RequestException as e:
-        print(f"SKIP {addr}: {e}")
+        skipped.append((addr, w, str(e)))
         time.sleep(DELAY)
         continue
 
@@ -182,16 +193,29 @@ for p in participants:
 total = sum(weight(p) for p in participants)
 intent_weight = sum(w for _, w in intents)
 
+nonzero_intents = [(a, w) for a, w in intents if w > 0]
+zero_intents = [(a, w) for a, w in intents if w == 0]
+
 print(f"Active participants: {len(participants)}")
 print(f"With {MODEL} in models[]: {len(with_kimi_model)} (not same as intent)")
 print()
 print("Intent from (PoCDirectIntent on chain):")
-for addr, w in intents:
+for addr, w in nonzero_intents:
     print(f"  {addr} : {w}")
+if zero_intents:
+    print()
+    print("Zero-weight intents (count toward V_min, contribute 0 to W_threshold):")
+    for addr, _ in zero_intents:
+        print(f"  {addr} : 0")
 print()
 print(f"Intent weight: {intent_weight} / {total}")
 if total:
     print(f"Intent share: {100.0 * intent_weight / total:.2f}%")
+if skipped:
+    print()
+    print(f"Skipped {len(skipped)} participants after retries (intent may be undercounted):")
+    for addr, w, err in skipped:
+        print(f"  {addr} (weight={w}): {err}")
 ```
 
 #### 2. Send delegation or refusal

--- a/docs/host/minimax-bootstrap.md
+++ b/docs/host/minimax-bootstrap.md
@@ -16,27 +16,36 @@ For current deployment defaults (including `node-config.json`), see the [Host Qu
 
 ## Timeline
 
-Punishment for missing MiniMax-M2.7 starts at **epoch `271`**. Each epoch from upgrade activation onwards, the chain attempts to bootstrap the model: it captures a `BootstrapDelegationSnapshot` 500 blocks (the `DeployWindow`) before that epoch's PoC stage, evaluates pre-eligibility against `V_min = 3` direct committers and `W_threshold = 0.3` of total network weight with `>2/3` reachability via INTENT + DELEGATE, and (if pre-eligible) starts PoC for MiniMax that epoch.
+Punishment for missing MiniMax-M2.7 starts at **epoch `271`**. Each epoch from upgrade activation onwards, the chain attempts to bootstrap the model: it captures a `BootstrapDelegationSnapshot` 500 blocks (the `DeployWindow`) before that epoch's PoC stage, evaluates pre-eligibility against `V_min = 3` direct committers and a `W_threshold` fraction of total network weight with `>2/3` reachability via INTENT + DELEGATE, and (if pre-eligible) starts PoC for MiniMax that epoch.
 
-To compute the exact block numbers for any given evaluation epoch:
+The current `W_threshold` is a governance parameter — read it from the chain rather than hard-coding a value (it was lowered from `0.3` to `0.1` by GIP-48, and may change again):
+
+```bash
+curl -s "https://node3.gonka.ai/chain-api/productscience/inference/inference/params" \
+  | jq '.params.delegation_params.w_threshold'
+# {value, exponent} encodes a decimal: e.g. {"value":"1","exponent":-1} → 0.1 (10%).
+```
+
+To compute the exact block numbers for any given evaluation epoch, anchor on the chain's current epoch and forward-project. The `epoch_shift` parameter does not anchor to genesis (it gets stale across past epoch-length changes), so `epoch_shift + N * epoch_length` is wrong on mainnet — always anchor on the live current PoC_start instead:
 
 ```bash
 NODE=https://node3.gonka.ai
 
-# Read epoch params (epoch_length and epoch_shift) and current state.
 PARAMS=$(curl -s "$NODE/chain-api/productscience/inference/inference/params")
 EPOCH_LENGTH=$(echo "$PARAMS" | jq -r '.params.epoch_params.epoch_length | tonumber')
-EPOCH_SHIFT=$(echo "$PARAMS" | jq -r '.params.epoch_params.epoch_shift | tonumber')
 
-# PoC start for epoch N is: epoch_shift + N * epoch_length
+CURRENT=$(curl -s "$NODE/v1/epochs/current/participants" | jq '.active_participants')
+CURRENT_EPOCH=$(echo "$CURRENT" | jq -r '.epoch_id')
+CURRENT_POC_START=$(echo "$CURRENT" | jq -r '.poc_start_block_height')
+
 EPOCH=271                   # change to any target epoch
-POC_START=$(( EPOCH_SHIFT + EPOCH * EPOCH_LENGTH ))
+POC_START=$(( CURRENT_POC_START + (EPOCH - CURRENT_EPOCH) * EPOCH_LENGTH ))
 SNAPSHOT_BLOCK=$(( POC_START - 500 ))
 
-echo "Epoch $EPOCH: snapshot at block $SNAPSHOT_BLOCK, PoC starts at block $POC_START"
+echo "Epoch $EPOCH (current $CURRENT_EPOCH): snapshot at block $SNAPSHOT_BLOCK, PoC starts at block $POC_START"
 ```
 
-The same calculation works for any earlier evaluation epoch (264, 265, ...). MiniMax becomes pre-eligible at the earliest epoch where participating hosts plus delegations cover the thresholds.
+MiniMax becomes pre-eligible at the earliest epoch where participating hosts plus delegations cover the thresholds.
 
 
 ### Possible Scenarios
@@ -182,11 +191,21 @@ DELAY = 0.15
 
 def session():
     s = requests.Session()
-    s.mount("https://", HTTPAdapter(max_retries=Retry(total=5, backoff_factor=0.5)))
+    # Retry transient 5xx (node3 returns 503 for some poc_delegation lookups
+    # under load) so a single hiccup does not silently drop a participant
+    # from the result.
+    retry = Retry(
+        total=5,
+        backoff_factor=0.5,
+        status_forcelist=(502, 503, 504),
+        allowed_methods=("GET",),
+    )
+    s.mount("https://", HTTPAdapter(max_retries=retry))
     s.headers["Connection"] = "close"
     return s
 
 def weight(p):
+    # weight may be 0, missing, or literally null — all mean "no voting weight".
     return int(p.get("weight") or 0)
 
 def get_json(s, url):
@@ -202,6 +221,7 @@ participants = get_json(s, f"{NODE}/v1/epochs/current/participants")[
 
 intents = []
 with_minimax_model = []
+skipped = []  # participants whose poc_delegation lookup failed after retries
 
 for p in participants:
     addr = p["index"]
@@ -215,7 +235,7 @@ for p in participants:
             f"{NODE}/chain-api/productscience/inference/inference/poc_delegation/{addr}",
         )
     except requests.RequestException as e:
-        print(f"SKIP {addr}: {e}")
+        skipped.append((addr, w, str(e)))
         time.sleep(DELAY)
         continue
 
@@ -227,16 +247,29 @@ for p in participants:
 total = sum(weight(p) for p in participants)
 intent_weight = sum(w for _, w in intents)
 
+nonzero_intents = [(a, w) for a, w in intents if w > 0]
+zero_intents = [(a, w) for a, w in intents if w == 0]
+
 print(f"Active participants: {len(participants)}")
 print(f"With {MODEL} in models[]: {len(with_minimax_model)} (not same as intent)")
 print()
 print("Intent from (PoCDirectIntent on chain):")
-for addr, w in intents:
+for addr, w in nonzero_intents:
     print(f"  {addr} : {w}")
+if zero_intents:
+    print()
+    print("Zero-weight intents (count toward V_min, contribute 0 to W_threshold):")
+    for addr, _ in zero_intents:
+        print(f"  {addr} : 0")
 print()
 print(f"Intent weight: {intent_weight} / {total}")
 if total:
     print(f"Intent share: {100.0 * intent_weight / total:.2f}%")
+if skipped:
+    print()
+    print(f"Skipped {len(skipped)} participants after retries (intent may be undercounted):")
+    for addr, w, err in skipped:
+        print(f"  {addr} (weight={w}): {err}")
 ```
 
 #### 2. Send delegation or refusal


### PR DESCRIPTION
Addresses [GON-170](https://linear.app/gonka-core/issue/GON-170/docs-on-httpsgonkaai-docshostminimax-bootstrap) review feedback from @Maria Mitina and @dbogdan on the merged minimax-bootstrap PR (#1078), with the script fix also applied to kimi-bootstrap (Maria's comment covered both).

## Changes

### `docs/host/minimax-bootstrap.md`

- **W_threshold value (dbogdan 1).** Removed hardcoded `W_threshold = 0.3`. GIP-48 lowered it to 0.1 on 2026-05-05 and it remains a governance parameter, so the doc now points operators at the live chain query of `delegation_params.w_threshold` (with a one-liner showing how to decode the `{value, exponent}` form).
- **PoC_start formula (dbogdan 2).** Replaced the broken `epoch_shift + N * epoch_length` snippet with one that anchors on the chain's current epoch + current PoC_start (from `/v1/epochs/current/participants`) and forward-projects. The old formula was off by ~5,625 blocks (~8 hours) on mainnet because `epoch_shift` does not anchor to genesis — it gets stale across past epoch-length changes. Verified end-to-end: new snippet returns `4,182,316` for epoch 271, matching the chain-derived value dbogdan posted.

### `docs/host/kimi-bootstrap.md` + `docs/host/minimax-bootstrap.md` (script)

- **Retry on transient 5xx (Maria's comment).** The Python intent-discovery script's `Retry(total=5, backoff_factor=0.5)` did not include `status_forcelist`, so urllib3 retried only on connection errors and let HTTP 5xx bubble up. On mainnet I reproduced node3 returning 503 for ~22 of 49 participants on `/poc_delegation/{addr}`; the script's `except RequestException` silently `SKIP`'d each, dropping their intents from the totals. Added `status_forcelist=(502, 503, 504), allowed_methods=("GET",)`. Re-running against mainnet now processes all 49 participants with 0 skips.
- **Visibility for weight=0 intents.** Mainnet has at least one participant with `weight: null`. The script handled it numerically but silently rolled them into totals as zero contribution, so a zero-weight host that submitted intent looked invisible. Now prints them in a separate "Zero-weight intents" section (with a note that they count toward `V_min` but contribute 0 to `W_threshold`).
- **Skipped-participants summary.** If any post-retry skips remain, the script now prints them at the end so intent under-counts are not hidden in noise.

## Verification

Bash snippet (run against `node3.gonka.ai`):
```
Epoch 271 (current 270): snapshot at block 4181816, PoC starts at block 4182316
```

Python script (run against `node3.gonka.ai`):
```
Participants: 49, intents: 0, skipped: 0
```
(Pre-fix would report 22+ skipped.)

## Test plan

- [ ] Run the bash snippet against `node3.gonka.ai` and confirm it returns the same `POC_START` for epoch 271 as dbogdan's chain math.
- [ ] Run the Python script for both kimi and minimax against `node3.gonka.ai` and confirm 0 skips, no exceptions.
- [ ] Confirm the W_threshold sentence reads cleanly and the query example is correct.

## Notes

- The v0.2.13 "did not pass governance" banner from #1108 stays in place. These fixes are accurate regardless of when/whether v0.2.13 re-launches.