### PR TITLE
Add Cross-Chain Transfers section with IBC USDT withdrawal guide

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,6 +39,9 @@ nav:
     - Dashboard: wallet/dashboard.md
     - Pricing: wallet/pricing.md
 
+  - Cross-Chain Transfers:
+    - IBC USDT withdrawal guide: cross-chain-transfers/ibc-usdt-withdrawal-guide.md
+
   - Reference:
     - Transactions & governance: transactions-and-governance.md
     - Software upgrades: software-upgrades.md
@@ -165,6 +168,8 @@ plugins:
             Wallet & transfer guide: 钱包与转账指南
             Dashboard: 仪表盘
             Pricing: 价格
+            Cross-Chain Transfers: 跨链转账
+            IBC USDT withdrawal guide: IBC USDT 提现指南
             Reference: 参考
             Transactions & governance: 交易与治理
             Software upgrades: 软件升级


### PR DESCRIPTION
## Summary
- Adds a new top-level **Cross-Chain Transfers** section to the docs navigation, with `cross-chain-transfers/ibc-usdt-withdrawal-guide.md` as its first page.
- Adds Chinese `nav_translations` (跨链转账 / IBC USDT 提现指南) so the section appears in the ZH sidebar as well; the page itself falls back to the English content via the i18n plugin, consistent with how other untranslated pages (e.g. `software-upgrades.md`) work today.
- The page itself (Gonka → Kava Cosmos → Kava EVM → Ethereum walkthrough) was already present in `docs/` but was unreachable from the sidebar — this PR just publishes it.

## Test plan
- [x] `mkdocs build` passes locally with `strict: true`
- [x] Page renders at `/cross-chain-transfers/ibc-usdt-withdrawal-guide/` (EN) and `/zh/cross-chain-transfers/ibc-usdt-withdrawal-guide/` (ZH)
- [x] New section label appears in both EN ("Cross-Chain Transfers") and ZH ("跨链转账") sidebars
- [ ] Verify rendered nav on the deploy preview


Made with [Cursor](https://cursor.com)