### PR TITLE
docs(nav): nest Cross-Chain Transfers under Wallet, group by transport

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,15 +38,16 @@ nav:
     - Wallet & transfer guide: wallet/wallet-and-transfer-guide.md
     - Dashboard: wallet/dashboard.md
     - Pricing: wallet/pricing.md
-
-  - Cross-Chain Transfers:
-    - Ethereum-Gonka bridge overview: cross-chain-transfers/ethereum-bridge-overview.md
-    - How to wrap USDT from Ethereum to Gonka: cross-chain-transfers/how-to-wrap-usdt-from-ethereum-to-gonka.md
-    - How to withdraw wrapped USDT back to Ethereum: cross-chain-transfers/how-to-withdraw-wrapped-usdt-back-to-ethereum.md
-    - Transfer GNK from Gonka to Ethereum (WGNK) and back: cross-chain-transfers/transfer-gnk-from-gonka-to-ethereum-wgnk-and-back.md
-    - How to register a new bridge token: cross-chain-transfers/how-to-register-a-new-bridge-token.md
-    - IBC USDT withdrawal guide: cross-chain-transfers/ibc-usdt-withdrawal-guide.md
-    - Multisig participant guide: cross-chain-transfers/multisig_participant_guide.md
+    - Cross-chain transfers:
+      - Overview: cross-chain-transfers/ethereum-bridge-overview.md
+      - Ethereum bridge:
+        - Wrap USDT (Ethereum → Gonka): cross-chain-transfers/how-to-wrap-usdt-from-ethereum-to-gonka.md
+        - Withdraw USDT (Gonka → Ethereum): cross-chain-transfers/how-to-withdraw-wrapped-usdt-back-to-ethereum.md
+        - Transfer GNK ↔ WGNK: cross-chain-transfers/transfer-gnk-from-gonka-to-ethereum-wgnk-and-back.md
+        - Register a new bridge token: cross-chain-transfers/how-to-register-a-new-bridge-token.md
+        - Multisig participant guide: cross-chain-transfers/multisig_participant_guide.md
+      - IBC:
+        - IBC USDT withdrawal guide: cross-chain-transfers/ibc-usdt-withdrawal-guide.md
 
   - Reference:
     - Transactions & governance: transactions-and-governance.md
@@ -174,14 +175,16 @@ plugins:
             Wallet & transfer guide: 钱包与转账指南
             Dashboard: 仪表盘
             Pricing: 价格
-            Cross-Chain Transfers: 跨链转账
-            Ethereum-Gonka bridge overview: 以太坊-Gonka 跨链桥概述
-            How to wrap USDT from Ethereum to Gonka: 如何将 USDT 从以太坊包装至 Gonka
-            How to withdraw wrapped USDT back to Ethereum: 如何将包装的 USDT 提取回以太坊
-            Transfer GNK from Gonka to Ethereum (WGNK) and back: 在 Gonka 与以太坊之间转移 GNK (WGNK)
-            How to register a new bridge token: 如何注册新的跨链桥代币
-            IBC USDT withdrawal guide: IBC USDT 提现指南
+            Cross-chain transfers: 跨链转账
+            Overview: 概述
+            Ethereum bridge: 以太坊跨链桥
+            "Wrap USDT (Ethereum → Gonka)": "包装 USDT（以太坊 → Gonka）"
+            "Withdraw USDT (Gonka → Ethereum)": "提取 USDT（Gonka → 以太坊）"
+            "Transfer GNK ↔ WGNK": "转移 GNK ↔ WGNK"
+            Register a new bridge token: 注册新的跨链桥代币
             Multisig participant guide: 多签参与者指南
+            IBC: IBC
+            IBC USDT withdrawal guide: IBC USDT 提现指南
             Reference: 参考
             Transactions & governance: 交易与治理
             Software upgrades: 软件升级


### PR DESCRIPTION
## Summary
- Pull the formerly top-level **Cross-Chain Transfers** section into **Wallet** as a sub-tree, and group its pages by transport (Ethereum bridge vs IBC). This matches how Polygon, Arbitrum, Optimism and Avalanche organise cross-chain content — users pick a path first, then the concrete operation, instead of reading a flat list of seven look-alike pages.
- No files moved — only `mkdocs.yml` nav and `nav_translations` updated; all existing `cross-chain-transfers/*.md` URLs stay the same.

New structure:

```
Wallet
  Wallet & transfer guide
  Dashboard
  Pricing
  Cross-chain transfers
    Overview
    Ethereum bridge
      Wrap USDT (Ethereum → Gonka)
      Withdraw USDT (Gonka → Ethereum)
      Transfer GNK ↔ WGNK
      Register a new bridge token
      Multisig participant guide
    IBC
      IBC USDT withdrawal guide
```

> Stacked on top of #1124 (Wallet rename). Once #1124 lands, please switch this PR's base to `main`.

## Test plan
- [ ] `mkdocs build --strict` passes locally (verified).
- [ ] EN sidebar: under "Wallet" → "Cross-chain transfers" the two subgroups "Ethereum bridge" and "IBC" expand correctly and all pages render.
- [ ] ZH sidebar: 钱包 → 跨链转账 → 以太坊跨链桥 / IBC — pages reachable and titles translated.
- [ ] Spot-check that none of the existing deep links to `cross-chain-transfers/*.md` broke (file paths are unchanged).

Made with [Cursor](https://cursor.com)