### PR TITLE
docs(bridge): rename Bridge GNK to Ethereum (WGNK) → Deposit GNK (Gonka → Ethereum)

### DIFF
--- a/docs/cross-chain-transfers/ethereum-bridge/deposit-gnk.md
+++ b/docs/cross-chain-transfers/ethereum-bridge/deposit-gnk.md
@@ -1,18 +1,20 @@
 !!! warning
-    为避免不必要的代币损失，在跨链桥完全激活的官方公告发布之前，请勿使用本指南中的说明。
+    To avoid unintentional loss of tokens, do not use these instructions before the official announcement that the bridge is fully activated.
 
-由 Gonka 共识控制的专用跨链桥智能合约已在以太坊上激活，地址为：
+The dedicated Bridge smart contract, controlled by the Gonka consensus, is active on Ethereum at the address:
 
 ```text
 0x972a7a92d92796a98801a8818bcf91f1648f2f68
 ```
 ---
 
-# 将 GNK 跨链至以太坊 (WGNK)
+# Deposit GNK (Gonka → Ethereum)
 
-### A) 请求在以太坊上铸造 WGNK
+Lock GNK on Gonka and receive wrapped GNK (**WGNK**) at your Ethereum address.
 
-使用 CLI 提交跨链桥铸造请求：
+### A) Request Minting WGNK on Ethereum
+
+Use CLI to submit a bridge minting request:
 
 ```bash
 ./inferenced tx inference request-bridge-mint \
@@ -27,39 +29,39 @@
 ```
 
 !!! tip
-    如果 `--gas auto` 的估算不准确，请根据返回状态中所需的 Gas 额度，并在命令中显式传递它（例如：`--gas 200000`）。
+    If `--gas auto` produces an incorrect gas estimation, check the returned status for the required gas limit and explicitly pass it (e.g., `--gas 200000`).
 
-#### 预期输出
+#### Expected Output
 ```text
 ...
 txhash: 12E8ABCA5A35D73042564FDF6D686424F742414EEC172450AB6EDA34BD1F0805
 ```
 
-等待几个区块生成，然后检查状态：
+Allow a couple of blocks to be mined, then check the status:
 
 ```bash
 ./inferenced query tx 12E8ABCA5A35D73042564FDF6D686424F742414EEC172450AB6EDA34BD1F0805
 ```
 
-确认 `"code": 0` 并提取 Base64 编码的 `request_id`：
+Verify that `"code": 0` and extract the base64 `request_id`:
 
 ```json
 "request_id": "vSTWiN1pvooxcFoDLzePCEq3x/C5NQ+jFMvfcEozCm4="
 ```
 
-将 Base64 编码的 `request_id` 转换为十六进制格式：
+Convert the base64 `request_id` to hexadecimal format:
 
 ```bash
 echo "vSTWiN1pvooxcFoDLzePCEq3x/C5NQ+jFMvfcEozCm4=" | base64 -d | xxd -p -c 256
 ```
-**十六进制输出示例：**
+**Example Hex Output:**
 ```text
 bd24d688dd69be8a31705a032f378f084ab7c7f0b9350fa314cbdf704a330a6e
 ```
 
-### B) 获取 BLS 签名状态
+### B) Get BLS Signature Status
 
-使用您的请求 ID 十六进制值查询 BLS 签名 API：
+Query the BLS signature API with your request ID hex:
 
 ```bash
 curl "https://node2.gonka.ai:8433/v1/bls/signatures/<REQUEST_ID_HEX>" \
@@ -72,9 +74,9 @@ curl "https://node2.gonka.ai:8433/v1/bls/signatures/<REQUEST_ID_HEX>" \
   '
 ```
 
-### C) 在以太坊上提交提取命令
+### C) Submit Withdrawal Command on Ethereum
 
-使用 [mint-wgnk.js](https://github.com/gonka-ai/gonka/blob/gm/contracts/proposals/ethereum-bridge-contact/mint-wgnk.js) 脚本向以太坊上的跨链桥合约提交铸造命令：
+Submit the mint command to the bridge contract on Ethereum using the [mint-wgnk.js](https://github.com/gonka-ai/gonka/blob/gm/contracts/proposals/ethereum-bridge-contact/mint-wgnk.js) script:
 
 ```bash
 HARDHAT_NETWORK=mainnet node mint-wgnk.js \

--- a/docs/zh/cross-chain-transfers/ethereum-bridge/deposit-gnk.md
+++ b/docs/zh/cross-chain-transfers/ethereum-bridge/deposit-gnk.md
@@ -1,18 +1,20 @@
 !!! warning
-    To avoid unintentional loss of tokens, do not use these instructions before the official announcement that the bridge is fully activated.
+    为避免不必要的代币损失，在跨链桥完全激活的官方公告发布之前，请勿使用本指南中的说明。
 
-The dedicated Bridge smart contract, controlled by the Gonka consensus, is active on Ethereum at the address:
+由 Gonka 共识控制的专用跨链桥智能合约已在以太坊上激活，地址为：
 
 ```text
 0x972a7a92d92796a98801a8818bcf91f1648f2f68
 ```
 ---
 
-# Bridge GNK to Ethereum (WGNK)
+# 存入 GNK（Gonka → 以太坊）
 
-### A) Request Minting WGNK on Ethereum
+在 Gonka 上锁定 GNK，并在你的以太坊地址上收到包装版的 GNK（**WGNK**）。
 
-Use CLI to submit a bridge minting request:
+### A) 请求在以太坊上铸造 WGNK
+
+使用 CLI 提交跨链桥铸造请求：
 
 ```bash
 ./inferenced tx inference request-bridge-mint \
@@ -27,39 +29,39 @@ Use CLI to submit a bridge minting request:
 ```
 
 !!! tip
-    If `--gas auto` produces an incorrect gas estimation, check the returned status for the required gas limit and explicitly pass it (e.g., `--gas 200000`).
+    如果 `--gas auto` 的估算不准确，请根据返回状态中所需的 Gas 额度，并在命令中显式传递它（例如：`--gas 200000`）。
 
-#### Expected Output
+#### 预期输出
 ```text
 ...
 txhash: 12E8ABCA5A35D73042564FDF6D686424F742414EEC172450AB6EDA34BD1F0805
 ```
 
-Allow a couple of blocks to be mined, then check the status:
+等待几个区块生成，然后检查状态：
 
 ```bash
 ./inferenced query tx 12E8ABCA5A35D73042564FDF6D686424F742414EEC172450AB6EDA34BD1F0805
 ```
 
-Verify that `"code": 0` and extract the base64 `request_id`:
+确认 `"code": 0` 并提取 Base64 编码的 `request_id`：
 
 ```json
 "request_id": "vSTWiN1pvooxcFoDLzePCEq3x/C5NQ+jFMvfcEozCm4="
 ```
 
-Convert the base64 `request_id` to hexadecimal format:
+将 Base64 编码的 `request_id` 转换为十六进制格式：
 
 ```bash
 echo "vSTWiN1pvooxcFoDLzePCEq3x/C5NQ+jFMvfcEozCm4=" | base64 -d | xxd -p -c 256
 ```
-**Example Hex Output:**
+**十六进制输出示例：**
 ```text
 bd24d688dd69be8a31705a032f378f084ab7c7f0b9350fa314cbdf704a330a6e
 ```
 
-### B) Get BLS Signature Status
+### B) 获取 BLS 签名状态
 
-Query the BLS signature API with your request ID hex:
+使用您的请求 ID 十六进制值查询 BLS 签名 API：
 
 ```bash
 curl "https://node2.gonka.ai:8433/v1/bls/signatures/<REQUEST_ID_HEX>" \
@@ -72,9 +74,9 @@ curl "https://node2.gonka.ai:8433/v1/bls/signatures/<REQUEST_ID_HEX>" \
   '
 ```
 
-### C) Submit Withdrawal Command on Ethereum
+### C) 在以太坊上提交提取命令
 
-Submit the mint command to the bridge contract on Ethereum using the [mint-wgnk.js](https://github.com/gonka-ai/gonka/blob/gm/contracts/proposals/ethereum-bridge-contact/mint-wgnk.js) script:
+使用 [mint-wgnk.js](https://github.com/gonka-ai/gonka/blob/gm/contracts/proposals/ethereum-bridge-contact/mint-wgnk.js) 脚本向以太坊上的跨链桥合约提交铸造命令：
 
 ```bash
 HARDHAT_NETWORK=mainnet node mint-wgnk.js \

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,7 +43,7 @@ nav:
         - Overview: cross-chain-transfers/ethereum-bridge/overview.md
         - Deposit USDT (Ethereum → Gonka): cross-chain-transfers/ethereum-bridge/deposit-usdt.md
         - Withdraw USDT (Gonka → Ethereum): cross-chain-transfers/ethereum-bridge/withdraw-usdt.md
-        - Bridge GNK to Ethereum (WGNK): cross-chain-transfers/ethereum-bridge/bridge-gnk.md
+        - Deposit GNK (Gonka → Ethereum): cross-chain-transfers/ethereum-bridge/deposit-gnk.md
         - Register a bridge token: cross-chain-transfers/ethereum-bridge/register-token.md
       - IBC:
         - Withdraw USDT via Kava (Gonka → Ethereum): cross-chain-transfers/ibc/withdraw-usdt-via-kava.md
@@ -182,7 +182,7 @@ plugins:
             Ethereum bridge: 以太坊跨链桥
             "Deposit USDT (Ethereum → Gonka)": "存入 USDT（以太坊 → Gonka）"
             "Withdraw USDT (Gonka → Ethereum)": "提取 USDT（Gonka → 以太坊）"
-            "Bridge GNK to Ethereum (WGNK)": "将 GNK 跨链至以太坊 (WGNK)"
+            "Deposit GNK (Gonka → Ethereum)": "存入 GNK（Gonka → 以太坊）"
             Register a bridge token: 注册跨链桥代币
             IBC: IBC
             "Withdraw USDT via Kava (Gonka → Ethereum)": "通过 Kava 提取 USDT（Gonka → 以太坊）"


### PR DESCRIPTION
## Summary

Bring the GNK page into the same verb-first pattern as the USDT pages so the four user-action items share a single shape:

| Before | After |
|---|---|
| Bridge GNK to Ethereum (WGNK) | Deposit GNK (Gonka → Ethereum) |

Resulting menu under Wallet → Cross-chain transfers → Ethereum bridge:

\`\`\`
Overview
Deposit USDT (Ethereum → Gonka)
Withdraw USDT (Gonka → Ethereum)
Deposit GNK (Gonka → Ethereum)        # this PR
Register a bridge token
\`\`\`

Why \`Deposit\` and not \`Bridge\`:

- USDT pair already uses Deposit/Withdraw. The GNK page describes the symmetric operation in the opposite direction (lock on source chain, receive wrapped on target), so the same verb fits.
- If we later add the reverse leg (WGNK → GNK), it will naturally be \"Withdraw GNK (Ethereum → Gonka)\" — pattern stays closed.

Dropped the in-title \"to Ethereum\" prose and trailing \"(WGNK)\" — the wrapped-token name now lives in a one-line lede on the page itself (EN and ZH).

File renamed \`bridge-gnk.md\` → \`deposit-gnk.md\` in both \`docs/cross-chain-transfers/ethereum-bridge/\` and the ZH mirror. No redirect needed: the old \`bridge-gnk\` URL only landed in main 30 min ago via #1126 and has not been shared.

## Test plan

- [ ] \`mkdocs build --strict\` passes locally (verified).
- [ ] Sidebar shows \"Deposit GNK (Gonka → Ethereum)\" in the Ethereum bridge subsection.
- [ ] Page renders with the new H1 and a single lede line introducing WGNK.
- [ ] ZH version mirrors the change.


Made with [Cursor](https://cursor.com)