### PR TITLE
docs(nav): hide Ethereum bridge subsection until the bridge upgrade

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,12 +39,16 @@ nav:
     - Dashboard: wallet/dashboard.md
     - Pricing: wallet/pricing.md
     - Cross-chain transfers:
-      - Ethereum bridge:
-        - Overview: cross-chain-transfers/ethereum-bridge/overview.md
-        - Deposit USDT (Ethereum → Gonka): cross-chain-transfers/ethereum-bridge/deposit-usdt.md
-        - Withdraw USDT (Gonka → Ethereum): cross-chain-transfers/ethereum-bridge/withdraw-usdt.md
-        - Deposit GNK (Gonka → Ethereum): cross-chain-transfers/ethereum-bridge/deposit-gnk.md
-        - Register a bridge token: cross-chain-transfers/ethereum-bridge/register-token.md
+      # Ethereum bridge subsection is hidden until the bridge upgrade is
+      # announced. Pages themselves stay in docs/cross-chain-transfers/ethereum-bridge/
+      # and remain reachable by direct URL — only the sidebar links are hidden.
+      # Uncomment as-is to republish.
+      # - Ethereum bridge:
+      #   - Overview: cross-chain-transfers/ethereum-bridge/overview.md
+      #   - Deposit USDT (Ethereum → Gonka): cross-chain-transfers/ethereum-bridge/deposit-usdt.md
+      #   - Withdraw USDT (Gonka → Ethereum): cross-chain-transfers/ethereum-bridge/withdraw-usdt.md
+      #   - Deposit GNK (Gonka → Ethereum): cross-chain-transfers/ethereum-bridge/deposit-gnk.md
+      #   - Register a bridge token: cross-chain-transfers/ethereum-bridge/register-token.md
       - IBC:
         - Withdraw USDT via Kava (Gonka → Ethereum): cross-chain-transfers/ibc/withdraw-usdt-via-kava.md
 
@@ -178,14 +182,16 @@ plugins:
             Dashboard: 仪表盘
             Pricing: 价格
             Cross-chain transfers: 跨链转账
-            Overview: 概述
-            Ethereum bridge: 以太坊跨链桥
-            "Deposit USDT (Ethereum → Gonka)": "存入 USDT（以太坊 → Gonka）"
-            "Withdraw USDT (Gonka → Ethereum)": "提取 USDT（Gonka → 以太坊）"
-            "Deposit GNK (Gonka → Ethereum)": "存入 GNK（Gonka → 以太坊）"
-            Register a bridge token: 注册跨链桥代币
             IBC: IBC
             "Withdraw USDT via Kava (Gonka → Ethereum)": "通过 Kava 提取 USDT（Gonka → 以太坊）"
+            # Hidden together with the Ethereum bridge nav block above.
+            # Uncomment in sync when republishing.
+            # Overview: 概述
+            # Ethereum bridge: 以太坊跨链桥
+            # "Deposit USDT (Ethereum → Gonka)": "存入 USDT（以太坊 → Gonka）"
+            # "Withdraw USDT (Gonka → Ethereum)": "提取 USDT（Gonka → 以太坊）"
+            # "Deposit GNK (Gonka → Ethereum)": "存入 GNK（Gonka → 以太坊）"
+            # Register a bridge token: 注册跨链桥代币
             Reference: 参考
             Transactions & governance: 交易与治理
             Software upgrades: 软件升级


### PR DESCRIPTION
## Summary

Hide the Ethereum bridge subsection from the sidebar until the bridge upgrade is announced. Files stay in the repo and at their published URLs — only the menu entries are hidden.

### Before
\`\`\`
Wallet
  …
  Cross-chain transfers
    Ethereum bridge
      Overview
      Deposit USDT (Ethereum → Gonka)
      Withdraw USDT (Gonka → Ethereum)
      Deposit GNK (Gonka → Ethereum)
      Register a bridge token
    IBC
      Withdraw USDT via Kava (Gonka → Ethereum)
\`\`\`

### After
\`\`\`
Wallet
  …
  Cross-chain transfers
    IBC
      Withdraw USDT via Kava (Gonka → Ethereum)
\`\`\`

The Ethereum bridge nav block (and its zh translations) is **commented out**, not deleted, so re-publishing after the upgrade is a single uncomment in \`mkdocs.yml\` — no need to re-derive the structure or remember labels.

Direct URLs that keep working without sidebar entries:

- /docs/cross-chain-transfers/ethereum-bridge/overview/
- /docs/cross-chain-transfers/ethereum-bridge/deposit-usdt/
- /docs/cross-chain-transfers/ethereum-bridge/withdraw-usdt/
- /docs/cross-chain-transfers/ethereum-bridge/deposit-gnk/
- /docs/cross-chain-transfers/ethereum-bridge/register-token/
- /docs/cross-chain-transfers/ethereum-bridge/multisig-signer-guide/
- /docs/cross-chain-transfers/multisig_participant_guide/ → redirect to multisig-signer-guide/ (unchanged)

## Test plan
- [ ] \`mkdocs build --strict\` passes (verified locally).
- [ ] Sidebar under Wallet → Cross-chain transfers shows only the IBC subgroup.
- [ ] Direct URLs above still render the page contents.
- [ ] ZH sidebar mirrors the EN structure.


Made with [Cursor](https://cursor.com)