### PR TITLE
Fix Hardware Eligibility section in minimax-bootstrap.md

### DIFF
--- a/docs/host/minimax-bootstrap.md
+++ b/docs/host/minimax-bootstrap.md
@@ -67,10 +67,10 @@ If MiniMax passes both checks, punishment follows the usual scenarios described 
 
 ## Hardware eligibility
 
-MiniMax-M2.7 (FP8) requires **roughly 320 GB of total VRAM**. This is a meaningfully smaller footprint than Kimi K2.6 (≥720 GB) and Qwen3-235B (≥720 GB). Practical implications:
+MiniMax-M2.7 (FP8) requires **roughly 320 GB of total VRAM** per instance — a meaningfully smaller footprint than Kimi K2.6 or Qwen3-235B, which both require ≥640 GB per instance per the [host quickstart reference layout](./quickstart.md#hardware-and-machines). Practical implications:
 
 - **A100 80GB owners**: MiniMax-M2.7 is the **first governance-approved model that fits the A100 80GB envelope**. If you previously could not host Kimi or Qwen-235B, you are now eligible to earn consensus weight via MiniMax. Recommended config: 8×A100 80GB with `tp=4` (two instances per host) or `tp=8` (one instance).
-- **H100 / H200 owners**: MiniMax-M2.7 has the highest per-8xGPU consensus output on this hardware tier (clearly above Kimi K2.6 after Kimi's coefficient adjustment in `v0.2.13`, and slightly above Qwen3-235B). Switching from Qwen or Kimi to MiniMax on H100/H200 is the network-preferred direction.
+- **H100 / H200 owners**: MiniMax-M2.7 is comparable to Qwen3-235B on consensus output (a few percent in either direction depending on workload mix) and clearly preferable to Kimi K2.6 after Kimi's coefficient adjustment in `v0.2.13`. Switching from Kimi to MiniMax is recommended; switching from Qwen to MiniMax is operator preference.
 - **B200 / B300 owners**: MiniMax-M2.7 runs well, but Kimi K2.6 retains a narrow consensus-output lead on flagship hardware. No change required if you already run Kimi.
 
 


### PR DESCRIPTION
Urgent fix per @Tania Charchian's flag (errors reported in the operator DevOps chat against [the published Hardware Eligibility section](https://gonka.ai/docs/host/minimax-bootstrap/#hardware-eligibility)).

## Two corrections

### 1. H100 / H200 ranking (already agreed)

Previous text said MiniMax-M2.7 is "clearly above Kimi K2.6... and slightly above Qwen3-235B" on H100/H200. The latest calibration has it **comparable to Qwen3-235B** (a few percent in either direction depending on workload mix), not above. Kimi after the v0.2.13 coefficient drop is clearly worse than both. Updated to match the v0.2.13 announcement phrasing that Tania and I aligned on a few days ago.

Defense: chain values pin Qwen `weight_scale_factor=0.3593` > MiniMax `0.3024` per PoC unit, so MiniMax can only come out ahead on H100/H200 if its throughput on that hardware is large enough to offset the weight-scale gap. Empirically it's a wash.

### 2. VRAM numbers were inconsistent with quickstart.md

The previous text claimed Kimi K2.6 and Qwen3-235B both require **≥720 GB** per instance. That figure:

- Matches no standard config (8×H100 = 640, 8×H200 = 1128, 8×B200 = 1536).
- Disagrees with `docs/host/quickstart.md`, which lists **640 GB** per MLNode for both.

Replaced the hard-coded numbers with a link to the quickstart's canonical reference layout (640 GB) so the two pages don't drift again.

## Outstanding

@Tania Charchian — separately on the PoC Intent command issue you flagged: I checked both the source file at `docs/host/minimax-bootstrap.md:81-91` and the live published site at `https://gonka.ai/docs/host/minimax-bootstrap/#1-send-pocintent-to-the-chain`, and both show the correct model (`MiniMaxAI/MiniMax-M2.7`) and `--gas-adjustment 1.3` is present. Could you screenshot what you're seeing in your browser? Possibly a stale cache or a different page. Will address as a separate commit on this PR once we know what's wrong.

If there are other errors in Hardware Eligibility I missed (e.g., B200/B300 framing, A100 80GB `tp=4` recommendation, MiniMax VRAM = 320 GB), please point at the specific text from the DevOps chat and I'll fold those into this PR too.

## Test plan

- [ ] Eyeball the rendered page at `localhost:8000` (or whatever local mkdocs serve runs on) — confirm the Hardware Eligibility section renders with the updated H100/H200 line and the new quickstart link.
- [ ] Confirm the quickstart link anchor (`#hardware-and-machines`) resolves correctly. If quickstart uses a different anchor for that section, update.