### PR TITLE
Fix Ethereum bridge docs (QA-18/19/20)

### DIFF
--- a/docs/cross-chain-transfers/ethereum-bridge/deposit-gnk.md
+++ b/docs/cross-chain-transfers/ethereum-bridge/deposit-gnk.md
@@ -21,11 +21,12 @@ Use CLI to submit a bridge minting request:
   <amount> \
   "0xYourEthereumAddr" \
   "ethereum" \
+  --destination-bridge-address 0x972a7a92d92796a98801a8818bcf91f1648f2f68 \
   --from <your_key_name> \
   --chain-id gonka-mainnet \
-  --gas auto \
+  --gas auto --gas-adjustment 1.5 \
   -y \
-  --node http://node2.gonka.ai:8000/chain-rpc/
+  --node http://node1.gonka.ai:8000/chain-rpc/
 ```
 
 !!! tip
@@ -40,7 +41,7 @@ txhash: 12E8ABCA5A35D73042564FDF6D686424F742414EEC172450AB6EDA34BD1F0805
 Allow a couple of blocks to be mined, then check the status:
 
 ```bash
-./inferenced query tx 12E8ABCA5A35D73042564FDF6D686424F742414EEC172450AB6EDA34BD1F0805
+./inferenced query tx 12E8ABCA5A35D73042564FDF6D686424F742414EEC172450AB6EDA34BD1F0805 --node http://node1.gonka.ai:8000/chain-rpc/
 ```
 
 Verify that `"code": 0` and extract the base64 `request_id`:
@@ -64,7 +65,7 @@ bd24d688dd69be8a31705a032f378f084ab7c7f0b9350fa314cbdf704a330a6e
 Query the BLS signature API with your request ID hex:
 
 ```bash
-curl "https://node2.gonka.ai:8433/v1/bls/signatures/<REQUEST_ID_HEX>" \
+curl "https://node2.gonka.ai:8443/v1/bls/signatures/<REQUEST_ID_HEX>" \
   | jq -r '
     {
       uncompressed_signature_128: .uncompressed_signature_128,
@@ -74,7 +75,7 @@ curl "https://node2.gonka.ai:8433/v1/bls/signatures/<REQUEST_ID_HEX>" \
   '
 ```
 
-### C) Submit Withdrawal Command on Ethereum
+### C) Submit Mint Command on Ethereum
 
 Submit the mint command to the bridge contract on Ethereum using the [mint-wgnk.js](https://github.com/gonka-ai/gonka/blob/gm/contracts/proposals/ethereum-bridge-contact/mint-wgnk.js) script:
 
@@ -82,7 +83,7 @@ Submit the mint command to the bridge contract on Ethereum using the [mint-wgnk.
 HARDHAT_NETWORK=mainnet node mint-wgnk.js \
   0x972a7a92d92796a98801a8818bcf91f1648f2f68 \
   <current_epoch_id> \
-  <request_id> \
+  <request_id_base64> \
   <0xYourEthereumAddr> \
   <amount> \
   <uncompressed_signature_128>

--- a/docs/cross-chain-transfers/ethereum-bridge/deposit-usdt.md
+++ b/docs/cross-chain-transfers/ethereum-bridge/deposit-usdt.md
@@ -27,12 +27,15 @@ const tx = await usdtContract.transfer(
 await tx.wait();
 ```
 
+!!! warning
+    The wrapped balance does not appear immediately. The bridge waits for the deposit block to be **finalised** on Ethereum (about two epochs), so expect **15–20 minutes** between the Ethereum transaction being mined and the wrapped balance appearing on Gonka.
+
 ### B) Check Wrapped Token Balance on Gonka
 
 Query the wrapped tokens owned by your Gonka address:
 
 ```bash
-curl "https://node2.gonka.ai:8433/chain-api/productscience/inference/inference/wrapped_token_balances/{gonkaAddress}"
+curl "https://node2.gonka.ai:8443/chain-api/productscience/inference/inference/wrapped_token_balances/{gonkaAddress}"
 ```
 
 #### Example Response
@@ -65,7 +68,9 @@ export WUSDT_CONTRACT="gonka1CW20WrappedUSDTAddress"
   '{"transfer":{"recipient":"gonka1xxxxxxxx...","amount":"123456"}}' \
   --from <your_key_name> \
   --chain-id gonka-mainnet \
-  --gas auto
+  --gas auto --gas-adjustment 1.5 \
+  -y \
+  --node http://node1.gonka.ai:8000/chain-rpc/
 ```
 
 #### Example Output
@@ -77,7 +82,7 @@ txhash: 39E3D4B86CF6B0C8952C789F4D73DB9FE27DEA4BD25F3842BE9298C78980A51D
 Allow 2-3 blocks to be mined, then check the status of the transaction:
 
 ```bash
-./inferenced query tx 39E3D4B86CF6B0C8952C789F4D73DB9FE27DEA4BD25F3842BE9298C78980A51D
+./inferenced query tx 39E3D4B86CF6B0C8952C789F4D73DB9FE27DEA4BD25F3842BE9298C78980A51D --node http://node1.gonka.ai:8000/chain-rpc/
 ```
 
 !!! tip

--- a/docs/cross-chain-transfers/ethereum-bridge/withdraw-usdt.md
+++ b/docs/cross-chain-transfers/ethereum-bridge/withdraw-usdt.md
@@ -16,12 +16,12 @@ Initiate the withdrawal transaction using CLI:
 
 ```bash
 ./inferenced tx wasm execute <gonka1CW20WrappedUSDTAddress> \
-  '{"withdraw":{"amount":"<amount>","destination_address":"0xYourEthereumAddr"}}' \
+  '{"withdraw":{"amount":"<amount>","destination_address":"0xYourEthereumAddr","destination_bridge_address":"0x972a7a92d92796a98801a8818bcf91f1648f2f68"}}' \
   --from <your_key_name> \
   --chain-id gonka-mainnet \
-  --gas auto \
+  --gas auto --gas-adjustment 1.5 \
   -y \
-  --node http://node2.gonka.ai:8000/chain-rpc/
+  --node http://node1.gonka.ai:8000/chain-rpc/
 ```
 
 !!! tip
@@ -38,7 +38,7 @@ txhash: 12E8ABCA5A35D73042564FDF6D686424F742414EEC172450AB6EDA34BD1F0805
 Allow a couple of blocks to be mined, then query the transaction hash to obtain the request ID:
 
 ```bash
-./inferenced query tx 12E8ABCA5A35D73042564FDF6D686424F742414EEC172450AB6EDA34BD1F0805
+./inferenced query tx 12E8ABCA5A35D73042564FDF6D686424F742414EEC172450AB6EDA34BD1F0805 --node http://node1.gonka.ai:8000/chain-rpc/
 ```
 
 Ensure the output contains `"code": 0` (indicating success) and extract the base64-encoded `request_id`:
@@ -62,7 +62,7 @@ bd24d688dd69be8a31705a032f378f084ab7c7f0b9350fa314cbdf704a330a6e
 Query the BLS signature API with your request ID hex:
 
 ```bash
-curl "https://node2.gonka.ai:8433/v1/bls/signatures/<REQUEST_ID_HEX>" \
+curl "https://node2.gonka.ai:8443/v1/bls/signatures/<REQUEST_ID_HEX>" \
   | jq -r '
     {
       uncompressed_signature_128: .uncompressed_signature_128,
@@ -85,9 +85,9 @@ Use the [withdraw-tokens.js](https://github.com/gonka-ai/gonka/blob/gm/contracts
 HARDHAT_NETWORK=mainnet node withdraw-tokens.js \
   0x972a7a92d92796a98801a8818bcf91f1648f2f68 \
   <current_epoch_id> \
-  <request_id> \
+  <request_id_base64> \
   <destination_address> \
-  <USDT_contract_address> \
+  0xdAC17F958D2ee523a2206206994597C13D831ec7 \
   <amount> \
   <uncompressed_signature_128>
 ```


### PR DESCRIPTION
End-to-end tested on mainnet against bridge contract `0x972a7a92d92796a98801a8818bcf91f1648f2f68`. Each change maps to a verified blocker:

- **deposit-gnk §A**: missing `--destination-bridge-address` (chain rejects at `ValidateBasic` with *"destination bridge address cannot be empty"*). `--gas auto` alone under-estimates by ~2k gas; `--gas-adjustment 1.5` fixes the out-of-gas. The query-tx step requires an indexed node; `node2.gonka.ai` has `tx_index: off`, switched to `node1.gonka.ai`.
- **deposit-gnk §B / deposit-usdt §B / withdraw-usdt §C**: BLS-signature API port is `:8443`, not `:8433` (the latter times out).
- **deposit-gnk §C**: heading was "Submit Withdrawal Command on Ethereum" — copy-paste from the withdraw doc; corrected to "Submit Mint Command".
- **deposit-gnk §C / withdraw-usdt §D**: `mint-wgnk.js` / `withdraw-tokens.js` base64-decode their `request_id` argument; passing the hex form throws `Invalid requestId length: expected 32 bytes, got 48`. Renamed the placeholder to `<request_id_base64>` so the format is obvious.
- **deposit-usdt §B** (new admonition): wrapped balance is gated on Ethereum finality (~two epochs); measured ~17 minutes from Ethereum mine to wrapped balance on Gonka.
- **deposit-usdt §C and withdraw-usdt §A**: `--gas auto` under-estimates these wasm-execute messages too; added `--gas-adjustment 1.5`. Missing `-y` / `--node` in deposit-usdt §C caused defaults to localhost.
- **withdraw-usdt §A JSON**: missing required field `destination_bridge_address` — the CW-20 wrapped-USDT contract rejects with *"missing field 'destination_bridge_address'"*.
- **withdraw-usdt §D**: filled in the USDT mainnet contract address (was a `<USDT_contract_address>` placeholder).

Closes QA-18, QA-19, QA-20.
