### PR TITLE
docs(host): add Validate ML Node page documenting mlnode-validate skill

### DIFF
--- a/docs/host/benchmark-to-choose-optimal-deployment-config-for-llms.md
+++ b/docs/host/benchmark-to-choose-optimal-deployment-config-for-llms.md
@@ -4,6 +4,9 @@ Effective GPU utilization is critical for deploying large language models. Gonka
 
 To achieve the best results, vLLM requires careful, server-specific configuration. The optimal performance depends on both GPUs' characteristics and the speed of cross-GPU data transfer. This guide provides instructions on how to select vLLM parameters using the Qwen/Qwen3-32B-FP8 model as an example. We will also describe which parameters can be tuned for optimal performance without affecting validation and which parameters must remain unchanged.
 
+!!! note "Performance vs. correctness"
+    This guide is about **performance tuning** (`compressa-perf`, TP / PP). To validate that your deployment produces honest PoC vectors matching the golden reference for the target model, see [Validate ML Node Deployment](./mlnode-validation.md) (`mlnode-validate` skill in the [`gonka` repo](https://github.com/gonka-ai/gonka)).
+
 [Link to our vLLM fork](https://github.com/product-science/vllm/tree/productscience/v0.8.1).
 
 ## Understanding vLLM Parameters

--- a/docs/host/kimi-bootstrap.md
+++ b/docs/host/kimi-bootstrap.md
@@ -119,6 +119,10 @@ curl -X POST http://localhost:9200/admin/v1/nodes \
      }'
 ```
 
+#### 5. Validate your deployment
+
+The [`gonka` repo](https://github.com/gonka-ai/gonka) ships an agent skill, `mlnode-validate`, that validates a deployed ML Node against pre-computed honest PoC vectors for a specific model. For Kimi K2.6 the committed golden reference is `mlnode/packages/benchmarks/scripts/poc_validation/artifacts/moonshotai-kimi-k2.6.json` (200 vectors; recorded on 4×B200). See [Validate ML Node Deployment](./mlnode-validation.md) and [`skills/mlnode-validate/SKILL.md`](https://github.com/gonka-ai/gonka/blob/main/skills/mlnode-validate/SKILL.md).
+
 ## Instructions for hosts who are NOT going to deploy Kimi-K2.6
 
 #### 1. Check if you trust any host who is going to deploy Kimi K2.6 / send `PoCIntent`

--- a/docs/host/minimax-bootstrap.md
+++ b/docs/host/minimax-bootstrap.md
@@ -167,6 +167,10 @@ curl -X POST http://localhost:9200/admin/v1/nodes \
 
 For 4×B200 / 8×B200 deployments, use `--tensor-parallel-size 2` (two instances per 8×B200 box) or `--tensor-parallel-size 4` (one instance) depending on throughput preference. The chain `Model.ModelArgs` are minimal; deployment-side flags (`--tensor-parallel-size`, `--gpu-memory-utilization`, `--max-num-seqs`, etc.) are operator choices.
 
+#### 5. Validate your deployment
+
+The [`gonka` repo](https://github.com/gonka-ai/gonka) ships an agent skill, `mlnode-validate`, that validates a deployed ML Node against pre-computed honest PoC vectors for a specific model. For MiniMax M2.7 the committed golden reference is `mlnode/packages/benchmarks/scripts/poc_validation/artifacts/minimaxai-minimax-m2.7.json` (200 vectors; recorded on 2×H200). Ready-made `deploy/join/` configs are also available for `4×A100`, `4×H100`, `2×H200`, and `2×B200`. See [Validate ML Node Deployment](./mlnode-validation.md) and [`skills/mlnode-validate/SKILL.md`](https://github.com/gonka-ai/gonka/blob/main/skills/mlnode-validate/SKILL.md).
+
 
 ## Instructions for hosts who are NOT going to deploy MiniMax-M2.7
 

--- a/docs/host/mlnode-validation.md
+++ b/docs/host/mlnode-validation.md
@@ -1,0 +1,119 @@
+# Validate ML Node Deployment
+
+The [`gonka` repo](https://github.com/gonka-ai/gonka) ships an agent skill called `mlnode-validate` that validates a deployed ML Node against pre-computed honest PoC vectors for a specific model. The skill is self-contained inside the repo (no external code, no callback receiver).
+
+The skill is the contract; this page is a pointer. The single source of truth is [`skills/mlnode-validate/SKILL.md`](https://github.com/gonka-ai/gonka/blob/main/skills/mlnode-validate/SKILL.md) — required / optional inputs, deploy-config rules, golden-reference list, pass criteria, failure modes, and the report template.
+
+The skill is implemented by two Python scripts under `mlnode/packages/benchmarks/scripts/poc_validation/`:
+
+- `validate.py` — the main entry point (download → deploy → throughput → validate).
+- `make_artifact.py` — bakes a new artifact from a trusted MLNode that already serves the target model. Used when no committed golden reference exists for the requested model.
+
+## What the script does
+
+`validate.py` runs four phases against a running ML Node, printing `[i/4]` headers as it progresses:
+
+1. **`[1/4] download`** — ensures the requested HuggingFace repo is cached on the ML Node. Uses `POST /api/v1/models/status`, then `POST /api/v1/models/download` and polls `/models/status` until `DOWNLOADED`.
+2. **`[2/4] deploy`** — starts vLLM if it is not already running. `POST /api/v1/inference/up/async {model, dtype, additional_args}`, polls `GET /api/v1/inference/up/status` until `is_running == true`.
+3. **`[3/4] throughput`** — measures full-system PoC throughput. `POST /api/v1/inference/pow/init/generate` (params from the reference); the proxy fans out to every healthy vLLM replica with a different `group_id`. Samples `GET /api/v1/inference/pow/status` every `--sample-interval` for `--measure-seconds`. Reports per-replica `nonces_per_second` and the sum across replicas, then `POST /api/v1/inference/pow/stop`.
+4. **`[4/4] validate`** — `POST /api/v1/inference/pow/generate` with `wait=true`, `nonces=[...]`, `validation.artifacts=<artifact>`, and the full `stat_test` block (`dist_threshold`, `p_mismatch`, `fraud_threshold`). The MLNode recomputes the same nonces, runs the L2 per-nonce mismatch test, then the binomial fraud test. Returns `{n_total, n_mismatch, mismatch_nonces, p_value, fraud_detected}`.
+
+Each phase can be skipped via `--skip-download`, `--skip-deploy`, `--skip-throughput`, `--skip-validate`.
+
+After the four phases, the script writes three files into `mlnode/packages/benchmarks/data/experiments/<exp_name>_<ts>/`:
+
+- `validate_config.json` — resolved inputs only (MLNode URL, model, reference path + meta, deploy config, PoC params, `stat_test` with provenance, raw CLI args).
+- `validate_report.json` — full structured report (config + per-phase results + verdict). This is the audit trail.
+- `validate_report.txt` — short human-readable summary; first line after the banner is `verdict: <PASS|FAIL|...>`.
+
+## Required inputs
+
+Per [SKILL.md → Required inputs](https://github.com/gonka-ai/gonka/blob/main/skills/mlnode-validate/SKILL.md#required-inputs), the caller MUST supply both:
+
+- `MLNODE_URL` — base URL of the MLNode under test (e.g. `http://1.2.3.4:8080`). No default.
+- `MODEL` — target HuggingFace model id in full `org/repo` form (e.g. `MiniMaxAI/MiniMax-M2.7`, `moonshotai/Kimi-K2.6`, `Qwen/Qwen3-235B-A22B-Instruct-2507-FP8`). No default.
+
+## Deploy config: from the caller, not the golden
+
+This is a load-bearing rule from [SKILL.md → Deploy config: from the caller, not the golden](https://github.com/gonka-ai/gonka/blob/main/skills/mlnode-validate/SKILL.md#deploy-config-from-the-caller-not-the-golden):
+
+The golden artifact supplies **vectors, PoC params, and `stat_test`** — nothing else. Its `additional_args` field records which flags were used on the server that generated the vectors and is **FYI only**. It must not be used as a deploy default on a different server.
+
+The caller passes a deploy config (typically `deploy/join/node-config-<model>-<gpu>.json`) matching the GPU class of the server under test. The standard flow is to **bake a custom reference** combining the golden's vectors + params + `stat_test` with the caller's `args`, then pass it via `--reference`:
+
+```python
+import json, pathlib
+src = pathlib.Path('mlnode/packages/benchmarks/scripts/poc_validation/artifacts/<golden>.json')
+node_cfg = json.loads(pathlib.Path('deploy/join/node-config-<model>-<gpu>.json').read_text())
+
+d = json.loads(src.read_text())
+d['additional_args'] = list(node_cfg[0]['models']['<HF model id>']['args'])
+d['source'] = f"vectors from {src.name}; additional_args from deploy/join/node-config-<model>-<gpu>.json"
+dst = src.with_name(src.stem + '-<gpu>.json')
+dst.write_text(json.dumps(d, indent=2))
+```
+
+```bash
+python3 mlnode/packages/benchmarks/scripts/poc_validation/validate.py \
+    --mlnode-url "$MLNODE_URL" --model "$MODEL" --reference <dst>
+```
+
+The custom reference is per-deployment and not committed. The golden reference can be passed directly (without baking) only when the server under test is the same hardware class as the golden's recording server — that is the exception, not the default.
+
+The CLI flags `--tp-size`, `--max-model-len`, `--extra-arg`, `--dtype` exist for small one-off tweaks on top of a reference, but they cannot remove flags the reference already carries — so they are not a substitute for baking a custom reference when the deployment shape differs from the golden's.
+
+## Available golden references
+
+Per [SKILL.md → Available golden references](https://github.com/gonka-ai/gonka/blob/main/skills/mlnode-validate/SKILL.md#available-golden-references), the repo ships these under `mlnode/packages/benchmarks/scripts/poc_validation/artifacts/`. The auto-lookup `<sanitized model>.json` picks the default filename per model; variants beyond the default require an explicit `--reference <path>`.
+
+The "Recording context" column describes the server that generated the vectors (FYI only — these flags are NOT a deploy default for your validation; see [Deploy config: from the caller, not the golden](#deploy-config-from-the-caller-not-the-golden) above).
+
+| Model | Filename | Vectors | Recording context |
+|-------|----------|---------|-------------------|
+| `Qwen/Qwen3-0.6B` | `qwen-qwen3-0.6b.json` | 32 | local dev / single GPU |
+| `Qwen/Qwen3-235B-A22B-Instruct-2507-FP8` (default lookup) | `qwen-qwen3-235b-a22b-instruct-2507-fp8.json` | 32 | tp=4, FlashInfer baseline. Quick smoke test. |
+| `Qwen/Qwen3-235B-A22B-Instruct-2507-FP8` (extended) | `qwen-qwen3-235b-a22b-instruct-2507-fp8-deepgemm.json` | 2000 | tp=2, DeepGEMM MoE backend (`VLLM_USE_DEEP_GEMM=1`, `VLLM_MOE_USE_DEEP_GEMM=1`), recorded on 4xB200. Pass with `--reference`. |
+| `Qwen/Qwen3-235B-A22B-Instruct-2507-FP8` (pubkey-v2) | `qwen-qwen3-235b-a22b-instruct-2507-fp8-h200-pubkey-v2.json` | 200 | tp=4, recorded on 4xH200 with `public_key=test_pub_keys_v2`. Pass with `--reference`. |
+| `MiniMaxAI/MiniMax-M2.7` (default lookup) | `minimaxai-minimax-m2.7.json` | 200 | tp=2, FLASHINFER attention, fp8 kv-cache, max-model-len 180000, `--trust-remote-code`, minimax_m2 tool/reasoning parsers. Recorded on 2xH200. |
+| `moonshotai/Kimi-K2.6` (default lookup) | `moonshotai-kimi-k2.6.json` | 200 | tp=4 + expert-parallel, FLASHINFER_MLA attention, gpu-mem 0.95, max-model-len 240000, kimi_k2 tool/reasoning parsers, `--disable-custom-all-reduce`, `--trust-remote-code`. Recorded on 4xB200. |
+
+For Qwen3-235B the same model id has multiple references, exercising different code paths (tp-size, MoE backend, public_key) — see SKILL.md for the recommended multi-run pattern.
+
+## Ready-made deploy configs in `deploy/join/`
+
+The repo ships `node-config-*.json` files matching common GPU classes for each approved model:
+
+- `deploy/join/node-config-qwen235B-B200.json`
+- `deploy/join/node-config-kimik26-B200.json`
+- `deploy/join/node-config-kimik26-H200.json`
+- `deploy/join/node-config-minimax-A100.json`
+- `deploy/join/node-config-minimax-H100.json`
+- `deploy/join/node-config-minimax-H200.json`
+- `deploy/join/node-config-minimax-B200.json`
+
+These configs are also reproduced inline in the [Host Quickstart](./quickstart.md).
+
+## Pass criteria
+
+Per [SKILL.md → Pass criteria](https://github.com/gonka-ai/gonka/blob/main/skills/mlnode-validate/SKILL.md#pass-criteria):
+
+- **Clean PASS** — `validation.passed == true`, `validation.has_mismatches == false`, `n_mismatch == 0`, `fraud_detected == false`.
+- **PASS with mismatches within stat-test tolerance** — `validation.passed == true`, `validation.has_mismatches == true`, `n_mismatch > 0`, `fraud_detected == false`. The fraud test allows up to a few mismatches per `p_mismatch`. This is still a PASS.
+- **FAIL** — `validation.passed == false`, `fraud_detected == true`.
+
+Exit codes:
+
+- `0` — PASS (with or without mismatches inside tolerance), or the validate phase was skipped.
+- `2` — validation ran and the fraud test fired.
+- `1` — hard error before validation could run (download failed, deploy timed out, etc.).
+
+## When no artifact exists for the requested model
+
+`validate.py` looks up the artifact under `mlnode/packages/benchmarks/scripts/poc_validation/artifacts/`. If the file for `MODEL` is missing, the script exits `1` and prints the expected filename plus the exact `make_artifact.py` command to bake one against a trusted MLNode that already serves the model. The agent must not invent vectors or substitute a different model — see [SKILL.md → When no artifact exists for the requested model](https://github.com/gonka-ai/gonka/blob/main/skills/mlnode-validate/SKILL.md#when-no-artifact-exists-for-the-requested-model).
+
+## Related guides
+
+- [Host Quickstart](./quickstart.md) — initial deploy and `node-config.json` examples for every supported model and GPU class.
+- [ML Node Management](./mlnode-management.md) — adding / updating / enabling / disabling ML Nodes via the Admin API.
+- [Benchmark to Choose Optimal Deployment Config for LLMs](./benchmark-to-choose-optimal-deployment-config-for-llms.md) — performance tuning (TP / PP) via `compressa-perf`.
+- [Kimi K2.6 Bootstrap](./kimi-bootstrap.md) / [MiniMax-M2.7 Bootstrap](./minimax-bootstrap.md) — on-chain bootstrap timelines and `PoCIntent` / delegation transactions.

--- a/docs/host/quickstart.md
+++ b/docs/host/quickstart.md
@@ -777,6 +777,9 @@ Edit `node-config.json` so each ML Node entry lists the **one model** that node 
 
 For more details on the optimal deployment configuration, please refer to [this link](https://gonka.ai/host/benchmark-to-choose-optimal-deployment-config-for-llms/).
 
+!!! tip "Validate the deployment"
+    The [`gonka` repo](https://github.com/gonka-ai/gonka) ships an agent skill, `mlnode-validate`, that validates an ML Node against pre-computed honest PoC vectors for a specific model. Committed golden references are available for Qwen3-0.6B, Qwen3-235B (default + DeepGEMM + pubkey-v2 variants), Kimi K2.6, and MiniMax M2.7. See [Validate ML Node Deployment](./mlnode-validation.md).
+
 ### [Server] Pre-download Model Weights to Hugging Face Cache (HF_HOME)
 Inference nodes download model weights from Hugging Face.
 To make sure the model weights are ready for inference, you should download them before deployment.

--- a/docs/zh/host/benchmark-to-choose-optimal-deployment-config-for-llms.md
+++ b/docs/zh/host/benchmark-to-choose-optimal-deployment-config-for-llms.md
@@ -4,6 +4,9 @@
 
 为了获得最佳结果，vLLM 需要仔细的、特定于服务器的配置。最佳性能取决于 GPU 特性和跨 GPU 数据传输速度。本指南提供如何使用 Qwen/QwQ-32 模型作为示例选择 vLLM 参数的说明。我们还将描述哪些参数可以调整以获得最佳性能而不影响验证，以及哪些参数必须保持不变。
 
+!!! note "性能与正确性"
+    本指南讨论的是**性能调优**（`compressa-perf`、TP / PP）。要验证您的部署生成与目标模型黄金参考相匹配的诚实 PoC 向量，请参见[验证 ML 节点部署](./mlnode-validation.md)（[`gonka` 仓库](https://github.com/gonka-ai/gonka)中的 `mlnode-validate` 技能）。
+
 [链接到我们的 vLLM 分支](https://github.com/product-science/vllm/tree/productscience/v0.8.1)。
 
 ## 理解 vLLM 参数

--- a/docs/zh/host/mlnode-validation.md
+++ b/docs/zh/host/mlnode-validation.md
@@ -1,0 +1,118 @@
+# 验证 ML 节点部署
+
+[`gonka` 仓库](https://github.com/gonka-ai/gonka)中提供了一个名为 `mlnode-validate` 的智能体技能（agent skill），用于在特定模型上对已部署的 ML 节点进行验证，将其输出与预先计算的诚实 PoC 向量比对。该技能自包含于仓库内部（无外部代码，无回调接收方）。
+
+该技能的**契约**位于 [`skills/mlnode-validate/SKILL.md`](https://github.com/gonka-ai/gonka/blob/main/skills/mlnode-validate/SKILL.md) — 必填 / 可选输入、部署配置规则、黄金参考列表、通过判定标准、失败模式、报告模板的唯一权威来源。本页只是指引。
+
+技能由位于 `mlnode/packages/benchmarks/scripts/poc_validation/` 下的两个 Python 脚本实现：
+
+- `validate.py` — 主入口（download → deploy → throughput → validate）。
+- `make_artifact.py` — 当请求的模型尚无已提交的黄金参考时，针对一个已经服务该模型的可信 MLNode 烘焙一个新的 artifact。
+
+## 脚本做什么
+
+`validate.py` 针对正在运行的 ML 节点执行四个阶段，在运行过程中输出 `[i/4]` 头部：
+
+1. **`[1/4] download`** — 确保所请求的 HuggingFace 仓库已在 ML 节点上缓存。使用 `POST /api/v1/models/status`，必要时 `POST /api/v1/models/download` 并轮询 `/models/status` 直到 `DOWNLOADED`。
+2. **`[2/4] deploy`** — 若 vLLM 尚未运行则启动。`POST /api/v1/inference/up/async {model, dtype, additional_args}`，轮询 `GET /api/v1/inference/up/status` 直到 `is_running == true`。
+3. **`[3/4] throughput`** — 测量整套系统的 PoC 吞吐量。`POST /api/v1/inference/pow/init/generate`（参数取自 reference）；代理向每个健康的 vLLM 副本扇出不同的 `group_id`。按 `--sample-interval` 采样 `GET /api/v1/inference/pow/status` 持续 `--measure-seconds`。报告每副本的 `nonces_per_second` 以及跨副本总和，然后 `POST /api/v1/inference/pow/stop`。
+4. **`[4/4] validate`** — `POST /api/v1/inference/pow/generate`，带 `wait=true`、`nonces=[...]`、`validation.artifacts=<artifact>` 以及完整的 `stat_test` 块（`dist_threshold`、`p_mismatch`、`fraud_threshold`）。ML 节点重新计算相同的 nonce，运行 L2 单 nonce 不匹配检测，然后是二项式欺诈检测。返回 `{n_total, n_mismatch, mismatch_nonces, p_value, fraud_detected}`。
+
+可分别通过 `--skip-download`、`--skip-deploy`、`--skip-throughput`、`--skip-validate` 跳过任一阶段。
+
+四个阶段完成后，脚本将三个文件写入 `mlnode/packages/benchmarks/data/experiments/<exp_name>_<ts>/`：
+
+- `validate_config.json` — 仅解析后的输入（ML 节点 URL、模型、参考路径 + 元数据、部署配置、PoC 参数、带来源的 `stat_test`、原始 CLI 参数）。
+- `validate_report.json` — 完整的结构化报告（配置 + 每阶段结果 + 结论）。审计跟踪。
+- `validate_report.txt` — 简短的人类可读摘要；横幅之后的第一行即 `verdict: <PASS|FAIL|...>`。
+
+## 必填输入
+
+依据 [SKILL.md → Required inputs](https://github.com/gonka-ai/gonka/blob/main/skills/mlnode-validate/SKILL.md#required-inputs)，调用方必须同时提供：
+
+- `MLNODE_URL` — 被测 ML 节点的基础 URL（例如 `http://1.2.3.4:8080`）。无默认值。
+- `MODEL` — 目标 HuggingFace 模型 id，完整 `org/repo` 形式（例如 `MiniMaxAI/MiniMax-M2.7`、`moonshotai/Kimi-K2.6`、`Qwen/Qwen3-235B-A22B-Instruct-2507-FP8`）。无默认值。
+
+## 部署配置：来自调用方，而非来自 golden
+
+这是 [SKILL.md → Deploy config: from the caller, not the golden](https://github.com/gonka-ai/gonka/blob/main/skills/mlnode-validate/SKILL.md#deploy-config-from-the-caller-not-the-golden) 中的一条关键规则：
+
+golden artifact 只提供 **向量、PoC 参数和 `stat_test`**——仅此而已。其中的 `additional_args` 字段记录了生成这些向量的那台服务器上使用的标志，**仅供参考**，**不能**作为另一台服务器上的部署默认值。
+
+调用方传入与被测服务器 GPU 类匹配的部署配置（通常为 `deploy/join/node-config-<model>-<gpu>.json`）。标准流程是**烘焙一个自定义 reference**，把 golden 的 vectors + params + `stat_test` 与调用方的 `args` 组合在一起，然后通过 `--reference` 传入：
+
+```python
+import json, pathlib
+src = pathlib.Path('mlnode/packages/benchmarks/scripts/poc_validation/artifacts/<golden>.json')
+node_cfg = json.loads(pathlib.Path('deploy/join/node-config-<model>-<gpu>.json').read_text())
+
+d = json.loads(src.read_text())
+d['additional_args'] = list(node_cfg[0]['models']['<HF model id>']['args'])
+d['source'] = f"vectors from {src.name}; additional_args from deploy/join/node-config-<model>-<gpu>.json"
+dst = src.with_name(src.stem + '-<gpu>.json')
+dst.write_text(json.dumps(d, indent=2))
+```
+
+```bash
+python3 mlnode/packages/benchmarks/scripts/poc_validation/validate.py \
+    --mlnode-url "$MLNODE_URL" --model "$MODEL" --reference <dst>
+```
+
+自定义 reference 是按部署一次性的，不提交到仓库。仅当被测服务器与生成 golden 的服务器属于同一硬件类时，才可以直接传 golden（无需烘焙）——这是例外，不是默认。
+
+CLI 标志 `--tp-size`、`--max-model-len`、`--extra-arg`、`--dtype` 用于在已有 reference 之上做小幅一次性微调，但它们**无法移除** reference 已经携带的标志——因此当部署形态与 golden 的录制形态不同时，它们不能替代烘焙自定义 reference。
+
+## 可用的黄金参考
+
+依据 [SKILL.md → Available golden references](https://github.com/gonka-ai/gonka/blob/main/skills/mlnode-validate/SKILL.md#available-golden-references)，仓库在 `mlnode/packages/benchmarks/scripts/poc_validation/artifacts/` 下提供以下 reference。自动查找 `<sanitized model>.json` 为每个模型挑选默认文件；超出默认范围的变体需要显式 `--reference <path>`。
+
+"Recording context" 列描述生成向量的那台服务器（**仅供参考**——这些标志**不是**你做验证时的部署默认值；参见上面的「部署配置：来自调用方，而非来自 golden」一节）。
+
+| 模型 | 文件名 | 向量数 | Recording context |
+|------|--------|--------|--------------------|
+| `Qwen/Qwen3-0.6B` | `qwen-qwen3-0.6b.json` | 32 | 本地开发 / 单 GPU |
+| `Qwen/Qwen3-235B-A22B-Instruct-2507-FP8`（默认查找） | `qwen-qwen3-235b-a22b-instruct-2507-fp8.json` | 32 | tp=4，FlashInfer 基线。快速 smoke 测试。 |
+| `Qwen/Qwen3-235B-A22B-Instruct-2507-FP8`（扩展） | `qwen-qwen3-235b-a22b-instruct-2507-fp8-deepgemm.json` | 2000 | tp=2，DeepGEMM MoE 后端（`VLLM_USE_DEEP_GEMM=1`，`VLLM_MOE_USE_DEEP_GEMM=1`），录制于 4xB200。需 `--reference` 传入。 |
+| `Qwen/Qwen3-235B-A22B-Instruct-2507-FP8`（pubkey-v2） | `qwen-qwen3-235b-a22b-instruct-2507-fp8-h200-pubkey-v2.json` | 200 | tp=4，录制于 4xH200，`public_key=test_pub_keys_v2`。需 `--reference` 传入。 |
+| `MiniMaxAI/MiniMax-M2.7`（默认查找） | `minimaxai-minimax-m2.7.json` | 200 | tp=2，FLASHINFER attention，fp8 kv-cache，max-model-len 180000，`--trust-remote-code`，minimax_m2 tool / reasoning parsers。录制于 2xH200。 |
+| `moonshotai/Kimi-K2.6`（默认查找） | `moonshotai-kimi-k2.6.json` | 200 | tp=4 + expert-parallel，FLASHINFER_MLA attention，gpu-mem 0.95，max-model-len 240000，kimi_k2 tool / reasoning parsers，`--disable-custom-all-reduce`，`--trust-remote-code`。录制于 4xB200。 |
+
+对于 Qwen3-235B，同一模型 id 有多个 reference，分别走不同代码路径（tp-size、MoE 后端、public_key）——具体的多次运行建议见 SKILL.md。
+
+## `deploy/join/` 中现成的部署配置
+
+仓库提供与每个已批准模型在常见 GPU 类上匹配的 `node-config-*.json`：
+
+- `deploy/join/node-config-qwen235B-B200.json`
+- `deploy/join/node-config-kimik26-B200.json`
+- `deploy/join/node-config-kimik26-H200.json`
+- `deploy/join/node-config-minimax-A100.json`
+- `deploy/join/node-config-minimax-H100.json`
+- `deploy/join/node-config-minimax-H200.json`
+- `deploy/join/node-config-minimax-B200.json`
+
+这些配置也在[主机快速入门](./quickstart.md)中以内联形式给出。
+
+## 通过判定标准
+
+依据 [SKILL.md → Pass criteria](https://github.com/gonka-ai/gonka/blob/main/skills/mlnode-validate/SKILL.md#pass-criteria)：
+
+- **Clean PASS** — `validation.passed == true`，`validation.has_mismatches == false`，`n_mismatch == 0`，`fraud_detected == false`。
+- **PASS with mismatches within stat-test tolerance** — `validation.passed == true`，`validation.has_mismatches == true`，`n_mismatch > 0`，`fraud_detected == false`。欺诈检测在 `p_mismatch` 容差内允许少量不匹配，仍判为 PASS。
+- **FAIL** — `validation.passed == false`，`fraud_detected == true`。
+
+退出码：
+
+- `0` — PASS（带或不带容差内不匹配），或 validate 阶段被跳过。
+- `2` — validation 已运行且欺诈检测触发。
+- `1` — validation 能运行之前出现硬错误（下载失败、部署超时等）。
+
+## 当请求的模型没有 artifact 时
+
+`validate.py` 在 `mlnode/packages/benchmarks/scripts/poc_validation/artifacts/` 下查找 artifact。若 `MODEL` 对应文件缺失，脚本以 `1` 退出并打印期望的文件名以及用于针对已经在服务 `MODEL` 的可信 MLNode 烘焙一个 artifact 的精确 `make_artifact.py` 命令。智能体**不得**自行生成向量或替换为其他模型——见 [SKILL.md → When no artifact exists for the requested model](https://github.com/gonka-ai/gonka/blob/main/skills/mlnode-validate/SKILL.md#when-no-artifact-exists-for-the-requested-model)。
+
+## 相关指南
+
+- [主机快速入门](./quickstart.md) — 初始部署，以及面向每个受支持模型和 GPU 类的 `node-config.json` 示例。
+- [ML 节点管理](./mlnode-management.md) — 通过管理 API 添加 / 更新 / 启用 / 禁用 ML 节点。
+- [选择 LLM 最佳部署配置的基准测试](./benchmark-to-choose-optimal-deployment-config-for-llms.md) — 通过 `compressa-perf` 进行性能调优（TP / PP）。

--- a/docs/zh/host/quickstart.md
+++ b/docs/zh/host/quickstart.md
@@ -577,6 +577,9 @@ source config.env
 
 更多关于最优部署配置的说明请参阅 [此链接](https://gonka.ai/host/benchmark-to-choose-optimal-deployment-config-for-llms/)。
 
+!!! tip "验证部署"
+    [`gonka` 仓库](https://github.com/gonka-ai/gonka)提供了一个名为 `mlnode-validate` 的智能体技能，可针对预先计算的诚实 PoC 向量验证 ML 节点。已提交的黄金参考涵盖 Qwen3-0.6B、Qwen3-235B（默认 + DeepGEMM + pubkey-v2 变体）、Kimi K2.6 和 MiniMax M2.7。参见[验证 ML 节点部署](./mlnode-validation.md)。
+
 ### [服务器] 将模型权重预下载到 Hugging Face 缓存（HF_HOME）
 
 推理节点从 Hugging Face 下载模型权重。为确保推理前权重已就绪，应在部署前下载。

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,6 +25,7 @@ nav:
       - Genesis: host/genesis.md
     - Operate:
       - ML Node management: host/mlnode-management.md
+      - Validate ML Node: host/mlnode-validation.md
       - Multiple nodes: host/multiple-nodes.md
       - Edit public host info: host/host_info.md
       - Network Node API: host/network-node-api.md
@@ -170,6 +171,7 @@ plugins:
             Genesis: 创世
             Operate: 运维
             ML Node management: ML 节点管理
+            Validate ML Node: 验证 ML 节点
             "Multiple nodes": 多节点
             Edit public host info: 编辑主机公开信息
             "Network Node API": 网络节点 API


### PR DESCRIPTION
## Summary

Adds a new page **Host → Operate → Validate ML Node** documenting the `mlnode-validate` agent skill shipped at [`skills/mlnode-validate/SKILL.md`](https://github.com/gonka-ai/gonka/blob/main/skills/mlnode-validate/SKILL.md) in the `gonka-ai/gonka` repo. Content is derived strictly from `SKILL.md` plus the file listings in `deploy/join/` and `mlnode/packages/benchmarks/scripts/poc_validation/artifacts/` (using PR [gonka-ai/gonka#1260](https://github.com/gonka-ai/gonka/pull/1260) as the upstream reference for MiniMax M2.7 additions).

The new page covers:

- What the skill does (four phases: `download` → `deploy` → `throughput` → `validate`) with the actual HTTP endpoints called by `validate.py`.
- Required inputs (`MLNODE_URL`, `MODEL`) and the load-bearing rule **«Deploy config: from the caller, not the golden»** — the golden artifact supplies vectors / PoC params / `stat_test`, and `additional_args` must come from the operator's `deploy/join/node-config-<model>-<gpu>.json`, with the documented Python snippet for baking a per-deployment custom reference.
- The full table of committed golden references (Qwen3-0.6B, Qwen3-235B default/DeepGEMM/pubkey-v2, MiniMax M2.7, Kimi K2.6) with recording-context FYI.
- The `deploy/join/node-config-*.json` layout that ships with the repo.
- Pass criteria (Clean PASS / PASS-with-mismatches / FAIL) and exit codes (`0` / `1` / `2`).
- What happens when no artifact exists for the requested model.

Cross-links added from `host/quickstart.md`, `host/kimi-bootstrap.md` (new step 5), `host/minimax-bootstrap.md` (new step 5), and `host/benchmark-to-choose-optimal-deployment-config-for-llms.md`. Chinese translations and `mkdocs.yml` nav (`Host → Operate → Validate ML Node` / 验证 ML 节点) included.

## Files

- New: `docs/host/mlnode-validation.md`, `docs/zh/host/mlnode-validation.md`
- Modified: `docs/host/{quickstart,kimi-bootstrap,minimax-bootstrap,benchmark-to-choose-optimal-deployment-config-for-llms}.md`, `docs/zh/host/{quickstart,benchmark-to-choose-optimal-deployment-config-for-llms}.md`, `mkdocs.yml`

## Test plan

- [x] `mkdocs build --strict` passes (no new warnings introduced by this change; pre-existing INFO anchors on `zh/host/quickstart.md` and `host/minimax-bootstrap.md` → `quickstart.md#hardware-and-machines` remain unchanged).
- [ ] Visual review of the new page in the preview / staging deploy.
- [ ] Sanity-check the cross-links from `quickstart.md`, `kimi-bootstrap.md`, `minimax-bootstrap.md`, and the benchmark guide.

## Notes

- The PR upstream ([gonka-ai/gonka#1260](https://github.com/gonka-ai/gonka/pull/1260)) that adds the MiniMax M2.7 golden artifact and the `deploy/join/node-config-minimax-*.json` files is not yet merged at the time of writing this PR; the links above use `main`, so they will resolve once that PR lands. The page itself does not link to per-file content that doesn't exist on `main` yet — it only references filenames.
- All content is sourced from the gonka-ai/gonka repo; no editorial prescriptions about timing or operational caveats (e.g. «H200 still being signed off») were imported from external chat messages.

Made with [Cursor](https://cursor.com)