### PR TITLE
docs(bridge): add Register a token page to nav and update disclaimer

### DIFF
--- a/docs/cross-chain-transfers/ethereum-bridge/deposit-gnk.md
+++ b/docs/cross-chain-transfers/ethereum-bridge/deposit-gnk.md
@@ -1,5 +1,5 @@
 !!! warning
-    To avoid unintentional loss of tokens, do not use these instructions before the official announcement that the bridge is fully activated.
+    Always start with a small test transaction. Bridge transfers are irreversible, so before moving large amounts, send a small amount first and confirm it arrives as expected.
 
 The dedicated Bridge smart contract, controlled by the Gonka consensus, is active on Ethereum at the address:
 

--- a/docs/cross-chain-transfers/ethereum-bridge/deposit-usdt.md
+++ b/docs/cross-chain-transfers/ethereum-bridge/deposit-usdt.md
@@ -1,5 +1,5 @@
 !!! warning
-    To avoid unintentional loss of tokens, do not use these instructions before the official announcement that the bridge is fully activated.
+    Always start with a small test transaction. Bridge transfers are irreversible, so before moving large amounts, send a small amount first and confirm it arrives as expected.
 
 The dedicated Bridge smart contract, controlled by the Gonka consensus, is active on Ethereum at the address:
 

--- a/docs/cross-chain-transfers/ethereum-bridge/overview.md
+++ b/docs/cross-chain-transfers/ethereum-bridge/overview.md
@@ -1,7 +1,7 @@
 # Ethereum bridge overview
 
 !!! warning
-    To avoid unintentional loss of tokens, do not use these instructions before the official announcement that the bridge is fully activated.
+    Always start with a small test transaction. Bridge transfers are irreversible, so before moving large amounts, send a small amount first and confirm it arrives as expected.
 
 The dedicated Bridge smart contract, controlled by the Gonka consensus, is active on Ethereum at the address:
 

--- a/docs/cross-chain-transfers/ethereum-bridge/register-token.md
+++ b/docs/cross-chain-transfers/ethereum-bridge/register-token.md
@@ -1,5 +1,5 @@
 !!! warning
-    To avoid unintentional loss of tokens, do not use these instructions before the official announcement that the bridge is fully activated.
+    Always start with a small test transaction. Bridge transfers are irreversible, so before moving large amounts, send a small amount first and confirm it arrives as expected.
 
 The dedicated Bridge smart contract, controlled by the Gonka consensus, is active on Ethereum at the address:
 

--- a/docs/cross-chain-transfers/ethereum-bridge/withdraw-usdt.md
+++ b/docs/cross-chain-transfers/ethereum-bridge/withdraw-usdt.md
@@ -1,5 +1,5 @@
 !!! warning
-    To avoid unintentional loss of tokens, do not use these instructions before the official announcement that the bridge is fully activated.
+    Always start with a small test transaction. Bridge transfers are irreversible, so before moving large amounts, send a small amount first and confirm it arrives as expected.
 
 The dedicated Bridge smart contract, controlled by the Gonka consensus, is active on Ethereum at the address:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,7 @@ nav:
     - Cross-chain transfers:
       - Ethereum bridge:
         - Overview: cross-chain-transfers/ethereum-bridge/overview.md
+        - Register a token: cross-chain-transfers/ethereum-bridge/register-token.md
         - Deposit USDT (Ethereum → Gonka): cross-chain-transfers/ethereum-bridge/deposit-usdt.md
         - Withdraw USDT (Gonka → Ethereum): cross-chain-transfers/ethereum-bridge/withdraw-usdt.md
         - Deposit GNK (Gonka → Ethereum): cross-chain-transfers/ethereum-bridge/deposit-gnk.md
@@ -189,6 +190,7 @@ plugins:
             "Withdraw USDT via Kava (Gonka → Ethereum)": "通过 Kava 提取 USDT（Gonka → 以太坊）"
             Overview: 概述
             Ethereum bridge: 以太坊跨链桥
+            Register a token: 注册代币
             "Deposit USDT (Ethereum → Gonka)": "存入 USDT（以太坊 → Gonka）"
             "Withdraw USDT (Gonka → Ethereum)": "提取 USDT（Gonka → 以太坊）"
             "Deposit GNK (Gonka → Ethereum)": "存入 GNK（Gonka → 以太坊）"


### PR DESCRIPTION
## Summary
- Add the existing `register-token.md` page to the Ethereum bridge navigation in `mkdocs.yml` (placed after Overview), including the Chinese menu translation (`注册代币`).
- Replace the old activation warning ("To avoid unintentional loss of tokens, do not use these instructions before the official announcement that the bridge is fully activated.") with a standard industry-style caution to start with a small test transaction, across all five Ethereum bridge pages.

## Test plan
- [ ] `mkdocs build` succeeds with `strict: true`
- [ ] "Register a token" appears in the Ethereum bridge menu in both EN and ZH
- [ ] Updated disclaimer renders on overview, register-token, deposit-usdt, withdraw-usdt, and deposit-gnk pages

Made with [Cursor](https://cursor.com)