### PR TITLE
docs(bridge): keys/dashboard guides, ETH-as-WETH fix, group key, GNK return & tracker

### DIFF
--- a/docs/cross-chain-transfers/ethereum-bridge/addresses-and-keys.md
+++ b/docs/cross-chain-transfers/ethereum-bridge/addresses-and-keys.md
@@ -1,0 +1,89 @@
+!!! warning
+    Always start with a small test transaction. Bridge transfers are irreversible, so before moving large amounts, send a small amount first and confirm it arrives as expected.
+
+The dedicated Bridge smart contract, controlled by the Gonka consensus, is active on Ethereum at the address:
+
+```text
+0x972a7a92d92796a98801a8818bcf91f1648f2f68
+```
+
+---
+
+# Addresses and keys
+
+This is the single most important page to understand before bridging. **Read it before your first transfer.**
+
+## One key, two addresses
+
+Ethereum and Gonka both use the same kind of cryptographic key (a `secp256k1` key pair). A single private key therefore controls an account on **both** chains. The two chains only differ in how they turn the public key into a human-readable address:
+
+| Chain | Address format | How the address is derived from the public key |
+| --- | --- | --- |
+| Ethereum | `0x...` (20 bytes, hex) | `keccak256(uncompressed_public_key)` → last 20 bytes |
+| Gonka | `gonka1...` (bech32) | `ripemd160(sha256(compressed_public_key))` → bech32 with the `gonka` prefix |
+
+So a single private key produces **two different-looking addresses** — one `0x…` and one `gonka1…` — but both are controlled by that same key.
+
+## How the bridge decides where your tokens go
+
+When you deposit on Ethereum, you sign the transaction with your Ethereum private key. The Gonka bridge:
+
+1. Detects the finalized deposit transaction on Ethereum.
+2. **Recovers the public key** from your transaction's signature.
+3. Computes the **Gonka address** for that public key (the `gonka1…` standard derivation above).
+4. Mints/releases the bridged tokens to that `gonka1…` address.
+
+In other words: **the wrapped tokens are delivered to the Gonka address that belongs to the exact key that signed the Ethereum deposit.** To spend them, you must control that same key on Gonka.
+
+The reverse direction works the same way: when you burn/withdraw on the Gonka side, the destination Ethereum address is one you specify explicitly in the transaction.
+
+## The seed-phrase pitfall (read this!)
+
+Most users never see their raw private key — they only have a **seed phrase** (mnemonic) and let their wallet derive keys for them. This is convenient, but it creates a trap for bridging:
+
+A seed phrase does not map to a single key. Wallets derive keys from it using **BIP-44 derivation paths**, and each blockchain uses a **different path**:
+
+* Ethereum wallets use coin type **60** → path `m/44'/60'/0'/0/0`
+* Cosmos/Gonka wallets use coin type **118** → path `m/44'/118'/0'/0/0`
+
+Because the paths differ, the **same seed phrase produces two completely different private keys** for Ethereum and Gonka — and therefore two unrelated address pairs. If you deposit from a seed-derived Ethereum account and then look at the seed-derived Gonka account in your wallet, **they are not the same key**, so the bridged tokens will land on a `gonka1…` address your wallet is not showing you and may not control.
+
+!!! danger
+    Do **not** assume "same seed phrase = same account on both chains." For the bridge you need the **same private key** on both chains, not the same seed phrase. Using the standard, different derivation paths will send your funds to an address derived from your Ethereum key — which your Gonka wallet, derived on a different path, does not control.
+
+## How to get the matching Gonka address
+
+You have two options.
+
+### Option A — Use the dashboard (recommended)
+
+The Gonka dashboard solves the derivation for you. Connect the **same Ethereum wallet** you bridge with, and the dashboard derives and displays the correct `gonka1…` address that the bridge will use, shows your wrapped balances, and guides the deposit/withdraw flow. This avoids handling raw private keys yourself and removes the seed-phrase confusion described above.
+
+Open the dashboard at:
+
+```text
+https://node1.gonka.ai:8443/dashboard
+```
+
+### Option B — Import the same private key into the Gonka keyring
+
+If you work from the CLI, import the **exact same** `secp256k1` private key (hex) that controls your Ethereum account into the Gonka keyring. The resulting `gonka1…` address is the one the bridge mints to:
+
+```bash
+inferenced keys import-hex <key_name> <YOUR_PRIVATE_KEY_HEX>
+
+# Show the derived Gonka address
+inferenced keys show <key_name> -a
+```
+
+The address printed here is exactly the `gonka1…` address that will receive your bridged tokens, and the key can sign Gonka transactions (transfers, withdrawals) for them.
+
+!!! warning
+    Importing a raw private key exposes it to the machine and keyring you import it on. Prefer a file-based keyring (`--keyring-backend file`) on a secure machine, and never paste a private key that also guards significant Ethereum funds onto an untrusted host. When in doubt, use the dashboard.
+
+## Quick checklist
+
+* Decide which key you will bridge with **before** you start.
+* If you have USDT/ETH on an Ethereum address already: derive the matching `gonka1…` address from that key (dashboard, or `import-hex`).
+* If you want to use an existing Gonka address: derive the matching `0x…` Ethereum address from that key, fund it with the token and enough ETH for gas.
+* Always send a small test amount first and confirm it arrives on the expected `gonka1…` address.

--- a/docs/cross-chain-transfers/ethereum-bridge/addresses-and-keys.md
+++ b/docs/cross-chain-transfers/ethereum-bridge/addresses-and-keys.md
@@ -33,9 +33,9 @@ When you deposit on Ethereum, you sign the transaction with your Ethereum privat
 3. Computes the **Gonka address** for that public key (the `gonka1…` standard derivation above).
 4. Mints/releases the bridged tokens to that `gonka1…` address.
 
-In other words: **the wrapped tokens are delivered to the Gonka address that belongs to the exact key that signed the Ethereum deposit.** To spend them, you must control that same key on Gonka.
+In other words: **the wrapped tokens are delivered to the Gonka address that belongs to the exact key that signed the Ethereum deposit.** To spend them, you must use the same key on Gonka.
 
-The reverse direction works the same way: when you burn/withdraw on the Gonka side, the destination Ethereum address is one you specify explicitly in the transaction.
+The reverse direction is different: when you withdraw or burn on the Gonka side, you **explicitly specify the destination Ethereum address** in the transaction — it is not derived from a key.
 
 ## The seed-phrase pitfall (read this!)
 

--- a/docs/cross-chain-transfers/ethereum-bridge/addresses-and-keys.md
+++ b/docs/cross-chain-transfers/ethereum-bridge/addresses-and-keys.md
@@ -33,7 +33,7 @@ When you bridge tokens from Ethereum to Gonka, you send them to the bridge contr
 3. Computes the **Gonka address** for that public key (the `gonka1…` standard derivation above).
 4. Mints/releases the bridged tokens to that `gonka1…` address.
 
-In other words: **the wrapped tokens are delivered to the Gonka address that belongs to the exact key that signed the Ethereum deposit.** To spend them, you must use the same key on Gonka.
+In other words: **the wrapped tokens are delivered to the Gonka address generated from the same public key — and controlled by the same private key — that signed the Ethereum deposit.** To spend them, you must use the same key on Gonka.
 
 The reverse direction is different: when you withdraw or burn on the Gonka side, you **explicitly specify the destination Ethereum address** in the transaction — it is not derived from a key.
 

--- a/docs/cross-chain-transfers/ethereum-bridge/addresses-and-keys.md
+++ b/docs/cross-chain-transfers/ethereum-bridge/addresses-and-keys.md
@@ -35,7 +35,7 @@ When you bridge tokens from Ethereum to Gonka, you send them to the bridge contr
 
 In other words: **the wrapped tokens are delivered to the Gonka address generated from the same public key — and controlled by the same private key — that signed the Ethereum deposit.** To spend them, you must use the same key on Gonka.
 
-The reverse direction is different: when you withdraw or burn on the Gonka side, you **explicitly specify the destination Ethereum address** in the transaction — it is not derived from a key.
+In the reverse direction (Gonka → Ethereum), the destination Ethereum address is one you **specify explicitly** in the withdrawal transaction.
 
 ## The seed-phrase pitfall (read this!)
 

--- a/docs/cross-chain-transfers/ethereum-bridge/addresses-and-keys.md
+++ b/docs/cross-chain-transfers/ethereum-bridge/addresses-and-keys.md
@@ -26,7 +26,7 @@ So a single private key produces **two different-looking addresses** — one `0x
 
 ## How the bridge decides where your tokens go
 
-When you deposit on Ethereum, you sign the transaction with your Ethereum private key. The Gonka bridge:
+When you bridge tokens from Ethereum to Gonka, you send them to the bridge contract and sign that Ethereum transaction with your Ethereum private key. The Gonka bridge:
 
 1. Detects the finalized deposit transaction on Ethereum.
 2. **Recovers the public key** from your transaction's signature.

--- a/docs/cross-chain-transfers/ethereum-bridge/addresses-and-keys.md
+++ b/docs/cross-chain-transfers/ethereum-bridge/addresses-and-keys.md
@@ -35,7 +35,7 @@ When you bridge tokens from Ethereum to Gonka, you send them to the bridge contr
 
 In other words: **the wrapped tokens are delivered to the Gonka address generated from the same public key — and controlled by the same private key — that signed the Ethereum deposit.** To spend them, you must use the same key on Gonka.
 
-In the reverse direction (Gonka → Ethereum), the destination Ethereum address is one you **specify explicitly** in the withdrawal transaction.
+The reverse direction works the other way around: bridging **back to Ethereum**, you **specify the destination address explicitly** in the withdrawal transaction, whereas bridging **to Gonka** you cannot choose the recipient — it is fixed by your key.
 
 ## The seed-phrase pitfall (read this!)
 

--- a/docs/cross-chain-transfers/ethereum-bridge/dashboard.md
+++ b/docs/cross-chain-transfers/ethereum-bridge/dashboard.md
@@ -1,0 +1,48 @@
+!!! warning
+    Always start with a small test transaction. Bridge transfers are irreversible, so before moving large amounts, send a small amount first and confirm it arrives as expected.
+
+The dedicated Bridge smart contract, controlled by the Gonka consensus, is active on Ethereum at the address:
+
+```text
+0x972a7a92d92796a98801a8818bcf91f1648f2f68
+```
+
+---
+
+# Using the dashboard
+
+The dashboard is the easiest way to bridge. It handles the key derivation for you (see [Addresses and keys](addresses-and-keys.md)), so you don't need to import private keys or compute addresses by hand. Open it at:
+
+```text
+https://node1.gonka.ai:8443/dashboard
+```
+
+## What the dashboard does for you
+
+* **Derives the correct addresses.** Connect the Ethereum wallet you bridge with, and the dashboard shows the matching `gonka1…` address the bridge will deliver tokens to — so you always know where your wrapped tokens will land.
+* **Warns about seed-phrase accounts.** If you are using a wallet whose Ethereum and Gonka keys come from the same **mnemonic**, the dashboard detects this and warns you, because seed-derived accounts use different keys on each chain and would send funds to an address you don't control. Read [Addresses and keys](addresses-and-keys.md) for the full explanation.
+* **Shows your bridged balances** in a Bridge Assets section, so you can confirm a deposit arrived.
+* **Reports chain status**, so you can see if the chain is degraded before initiating a transfer.
+
+## Supported flows
+
+The dashboard supports the full set of transfers without using the CLI:
+
+* **Ethereum → Gonka**: deposit any ERC-20 (USDT, USDC, WETH, …) and receive the wrapped token on Gonka.
+* **Gonka → Ethereum**: withdraw a wrapped token back to an Ethereum address.
+* **GNK ↔ WGNK**: bridge native GNK to Ethereum as WGNK and back.
+
+## Typical deposit (Ethereum → Gonka)
+
+1. Open the dashboard and connect your Ethereum wallet.
+2. Confirm the derived `gonka1…` recipient address shown by the dashboard is one you control.
+3. Choose the token and amount and approve the transfer to the bridge contract.
+4. Wait ~15–20 minutes for Ethereum finalization (see [Timing & finalization](overview.md#timing-finalization)), then check the Bridge Assets section for your wrapped balance.
+
+## Typical withdrawal (Gonka → Ethereum)
+
+1. Connect, select the wrapped token and amount, and enter the destination **Ethereum** address.
+2. Approve the withdrawal. The dashboard collects the BLS signature for the current epoch and submits the release transaction to the bridge contract on Ethereum.
+
+!!! tip
+    Prefer the dashboard if you are not comfortable with the CLI or with handling raw private keys. The step-by-step CLI flows are documented in [Deposit USDT](deposit-usdt.md), [Withdraw USDT](withdraw-usdt.md), [Deposit GNK](deposit-gnk.md), and [Withdraw GNK](withdraw-gnk.md) if you prefer to do it manually.

--- a/docs/cross-chain-transfers/ethereum-bridge/deposit-gnk.md
+++ b/docs/cross-chain-transfers/ethereum-bridge/deposit-gnk.md
@@ -1,5 +1,5 @@
 !!! warning
-    To avoid unintentional loss of tokens, do not use these instructions before the official announcement that the bridge is fully activated.
+    Always start with a small test transaction. Bridge transfers are irreversible, so before moving large amounts, send a small amount first and confirm it arrives as expected.
 
 The dedicated Bridge smart contract, controlled by the Gonka consensus, is active on Ethereum at the address:
 

--- a/docs/cross-chain-transfers/ethereum-bridge/deposit-usdt.md
+++ b/docs/cross-chain-transfers/ethereum-bridge/deposit-usdt.md
@@ -15,6 +15,9 @@ To use an existing Ethereum address that already holds USDT, generate a Gonka ad
 
 If instead you want to use an existing Gonka address, generate the corresponding Ethereum address from the same private key, acquire USDT on it, and ensure you have enough ETH for gas.
 
+!!! important
+    The wrapped tokens are delivered to the `gonka1…` address **derived from the key that signs this Ethereum deposit** — not to a seed-derived Gonka account. If you skip this, your funds may land on an address you do not control. See [Addresses and keys](addresses-and-keys.md) for how to derive the correct address (or use the dashboard).
+
 ### A) Send USDT to the Bridge Contract on Ethereum
 
 Execute the transfer to the bridge contract:

--- a/docs/cross-chain-transfers/ethereum-bridge/deposit-usdt.md
+++ b/docs/cross-chain-transfers/ethereum-bridge/deposit-usdt.md
@@ -1,5 +1,5 @@
 !!! warning
-    To avoid unintentional loss of tokens, do not use these instructions before the official announcement that the bridge is fully activated.
+    Always start with a small test transaction. Bridge transfers are irreversible, so before moving large amounts, send a small amount first and confirm it arrives as expected.
 
 The dedicated Bridge smart contract, controlled by the Gonka consensus, is active on Ethereum at the address:
 

--- a/docs/cross-chain-transfers/ethereum-bridge/overview.md
+++ b/docs/cross-chain-transfers/ethereum-bridge/overview.md
@@ -1,7 +1,7 @@
 # Ethereum bridge overview
 
 !!! warning
-    To avoid unintentional loss of tokens, do not use these instructions before the official announcement that the bridge is fully activated.
+    Always start with a small test transaction. Bridge transfers are irreversible, so before moving large amounts, send a small amount first and confirm it arrives as expected.
 
 The dedicated Bridge smart contract, controlled by the Gonka consensus, is active on Ethereum at the address:
 

--- a/docs/cross-chain-transfers/ethereum-bridge/overview.md
+++ b/docs/cross-chain-transfers/ethereum-bridge/overview.md
@@ -11,9 +11,17 @@ The dedicated Bridge smart contract, controlled by the Gonka consensus, is activ
 
 The bridge allows you to move:
 
-* **ERC-20 tokens** (e.g., USDT) from Ethereum to Gonka and back.
-* **Native Ethereum coin (ETH)** to Gonka (as wrapped ETH) and back.
+* **Any ERC-20 token** (e.g., USDT, USDC, WETH) from Ethereum to Gonka and back.
 * **Native Gonka coin (GNK)** to Ethereum (as wrapped GNK) and back.
+
+!!! note "ETH is bridged as WETH"
+    The bridge tracks **ERC-20 token transfers** to the bridge contract. Native ETH is not an ERC-20, so to bridge ether you first wrap it into **WETH** (the standard Wrapped Ether ERC-20 token) on Ethereum, then bridge WETH exactly like any other ERC-20.
+
+!!! important "Any ERC-20 token works — registration is not required"
+    You can bridge **any** ERC-20 token, even one that has never been registered on Gonka. When the deposit is recognized, the bridge automatically creates the wrapped CW-20 contract and mints your balance. Registration through governance is **optional** and only adds display metadata (name, symbol, decimals) and trading eligibility — it is **not** needed to move tokens. See [Register a bridge token](register-token.md) for details.
+
+!!! important "Both addresses come from the same key"
+    Gonka delivers wrapped tokens to the Gonka address **derived from the same private key** that signed your Ethereum deposit. If your Ethereum and Gonka keys come from a seed phrase, they are usually **different** keys and this will not work. Read [Addresses and keys](addresses-and-keys.md) **before** your first transfer.
 
 ---
 
@@ -21,11 +29,12 @@ The bridge allows you to move:
 
 ### Wrapping ERC-20 Tokens (e.g., USDT) from Ethereum to Gonka
 1. **Deposit**: The owner of the ERC-20 token sends their tokens to the bridge smart contract address on Ethereum.
-2. **Locking & Minting**: The tokens become locked in the contract. Once the transaction is recognized by the Gonka consensus, the bridge mints wrapped versions of that ERC-20 on the Gonka chain as CW-20 tokens. Each wrapped asset has a unique token address that can only be created by the bridge.
-3. **Ownership**: After minting, ownership of the wrapped tokens is assigned to the Gonka address derived from the same private/public key pair used on Ethereum. From this point, the owner can freely transfer the wrapped tokens to any other Gonka account.
+2. **Locking & Minting**: The tokens become locked in the contract. Each Gonka host runs a small bridge container that watches the bridge address. Once the deposit is **finalized** on Ethereum and **more than 50% of the hosts (by voting power)** have independently confirmed it, the bridge mints wrapped versions of that ERC-20 on the Gonka chain as CW-20 tokens.
+3. **One wrapped contract per token**: Each Ethereum token maps to exactly **one** wrapped CW-20 contract on Gonka (keyed by chain ID + Ethereum contract address). The first deposit of a given token instantiates that contract; every later deposit of the **same** token reuses the **same** wrapped contract. Only the bridge can create or mint these contracts.
+4. **Ownership**: After minting, ownership of the wrapped tokens is assigned to the Gonka address derived from the same private/public key pair used on Ethereum. From this point, the owner can freely transfer the wrapped tokens to any other Gonka account.
 
 !!! note
-    Wrapped tokens on the Gonka side must be registered on-chain through a governance proposal. Initially, the official USDT and USDC tokens are pre-registered. For instructions on how to register new tokens, see [Register a bridge token](register-token.md).
+    Registering a token (see [Register a bridge token](register-token.md)) is optional. It does not affect whether a token can be bridged — it only attaches metadata so the wrapped token shows a proper name/symbol/decimals in wallets and dashboards, and makes it eligible for the on-chain liquidity pool. USDT and USDC are pre-registered. You can bridge and test any other ERC-20 without registering it first.
 
 ### Unwrapping / Withdrawing back to Ethereum
 1. **Request**: The owner submits a special withdrawal transaction on the Gonka chain. This locks/burns the wrapped token and triggers BLS signature generation.
@@ -36,6 +45,68 @@ The bridge allows you to move:
 1. **Escrow**: A special transaction locks GNK on an escrow account and triggers BLS signature generation.
 2. **Execution**: The generated BLS signature is submitted to the bridge contract on Ethereum to mint WGNK to the target Ethereum address.
 
-### Wrapping Native ETH to Gonka (WETH)
-1. **Deposit**: ETH is transferred to the bridge contract on Ethereum, where it is locked.
-2. **Minting**: Once recognized by Gonka consensus, the bridge mints wrapped ETH (WETH) on the Gonka chain as CW-20 tokens and assigns them to the Gonka address derived from the owner's private key.
+!!! note
+    GNK never exists "natively" on Ethereum. On the Ethereum side it is always the wrapped **WGNK** ERC-20 token issued by the bridge contract. "Bridging GNK to Ethereum" means locking native GNK in escrow on Gonka and minting the equivalent WGNK on Ethereum.
+
+### Returning WGNK from Ethereum back to GNK
+1. **Burn**: WGNK is sent to the bridge contract on Ethereum, which burns it.
+2. **Release**: Once the burn is recognized by Gonka consensus, the equivalent native GNK is released from escrow to the Gonka address derived from the same key that burned the WGNK. See [Withdraw GNK (Ethereum → Gonka)](withdraw-gnk.md).
+
+### Bridging ETH (as WETH)
+The bridge detects ERC-20 transfers, not native ETH transfers. To bring ether to Gonka:
+
+1. **Wrap**: Wrap your ETH into **WETH** (the standard Wrapped Ether ERC-20) on Ethereum.
+2. **Bridge**: Send the WETH to the bridge contract — it behaves like [any other ERC-20 deposit](deposit-usdt.md). Gonka mints the wrapped WETH as a CW-20 token to the Gonka address derived from the same key, and you can withdraw it back to Ethereum the same way.
+
+---
+
+## How Gonka → Ethereum is authorized (the daily group key)
+
+Every transfer **out** of Gonka (withdrawing a wrapped ERC-20/ETH, or minting WGNK) is released on Ethereum by a BLS signature from the Gonka validator set. For the Ethereum bridge contract to trust that signature, it must know the **current epoch's group key**, and it learns it through a daily chain of signatures:
+
+* At the start of each epoch (about **once per day**), Gonka generates a **new group key** and signs it with the **previous** epoch's key.
+* A small transaction must be submitted to the Ethereum bridge contract to register that new key. The contract only accepts the **next** sequential epoch key, signed by the previous one — so the key history forms an unbroken chain back to genesis.
+* **Anyone** can submit this update with the same public data.
+
+Once the current epoch's group key is registered, withdrawals are fast: a **single epoch signature can authorize any number of withdrawals** initiated during that epoch. The flow for a user is:
+
+1. Submit the withdrawal/mint operation on Gonka, specifying the **recipient Ethereum address**. This burns/escrows the asset and triggers BLS signing with the group key.
+2. Retrieve the produced signature.
+3. Submit the signature plus the transfer data to the bridge contract on Ethereum, which verifies it against the current group key and releases the ERC-20, ETH, or WGNK to the recipient.
+
+## Timing & finalization
+
+Transfer time depends on the direction:
+
+* **Ethereum → Gonka: about 15–20 minutes.** The bridge waits for the deposit block to be **finalized** on Ethereum (≈ two epochs) before minting. Gonka uses no intermediaries that front the funds and take on risk, so this wait is unavoidable. The exact time also depends on where in the Ethereum epoch your transaction lands.
+* **Gonka → Ethereum: fast.** The group key is formed once per epoch and used all day, so you can start a withdrawal at any time and only wait for the BLS signature and your Ethereum execution transaction.
+
+!!! warning "During a Gonka chain outage"
+    The bridge ingests **finalized Ethereum blocks** independently of Gonka block production. If the Gonka chain is halted, those Ethereum blocks (and the deposits in them) can be **skipped** by the hosts rather than queued, and withdrawals cannot be signed until signing resumes. If you ever see the chain reported as down on the [dashboard](tracker-integration.md), wait until it is healthy again before bridging.
+
+## Bridge vs. exchange
+
+The bridge only **locks an asset on one chain and releases it on the other** — it does not swap one asset for another. Trading happens on **separate** contracts:
+
+* On Ethereum, e.g. swap **WGNK ↔ USDC** on a DEX such as Uniswap.
+* On Gonka, swap wrapped tokens via the on-chain liquidity pool.
+
+So a typical "sell GNK on Ethereum" flow is: bridge GNK → WGNK to Ethereum, then trade WGNK for another token on a DEX.
+
+## Bridge vs. IBC
+
+This bridge connects Gonka directly with **Ethereum**. Gonka also supports **IBC** for transfers with other Cosmos chains (see the [IBC](../ibc/withdraw-usdt-via-kava.md) section).
+
+* Use the **Ethereum bridge** to move assets between **Ethereum and Gonka**. It is typically simpler and needs fewer gas tokens than routing through IBC.
+* A token bridged from Ethereum lives on Gonka as a wrapped CW-20 tied to this bridge. It can be transferred within Gonka and sent **back to Ethereum**, but it **cannot** be forwarded or sold onto another Cosmos chain — for that you would use an IBC-native asset.
+
+---
+
+## Where to next
+
+* [Addresses and keys](addresses-and-keys.md) — how a single private key controls both your Ethereum and Gonka addresses, and the seed-phrase pitfall.
+* [Using the dashboard](dashboard.md) — the easiest way to bridge, with no CLI or raw keys.
+* [Deposit USDT (Ethereum → Gonka)](deposit-usdt.md) and [Withdraw USDT (Gonka → Ethereum)](withdraw-usdt.md) — bridging an ERC-20 both ways.
+* [Deposit GNK (Gonka → Ethereum)](deposit-gnk.md) and [Withdraw GNK (Ethereum → Gonka)](withdraw-gnk.md) — bridging native GNK both ways.
+* [Register a bridge token](register-token.md) — optional metadata/trading registration.
+* [Dashboard & tracker integration](tracker-integration.md) — for explorer/tracker operators integrating bridge data.

--- a/docs/cross-chain-transfers/ethereum-bridge/register-token.md
+++ b/docs/cross-chain-transfers/ethereum-bridge/register-token.md
@@ -11,9 +11,22 @@ The dedicated Bridge smart contract, controlled by the Gonka consensus, is activ
 
 # Register a bridge token
 
-To allow users to bridge a new ERC-20 token from Ethereum to Gonka, the token must be registered on-chain. This is done through a governance proposal that registers the token's metadata (name, symbol, decimals) so the Gonka consensus and the bridge know how to instantiate the wrapped CW-20 token contract.
+!!! important "Registration is optional"
+    You do **not** need to register a token to bridge it. Any ERC-20 can be deposited to the bridge, and Gonka will automatically instantiate its wrapped CW-20 contract and mint your balance. Registration is a convenience that:
+
+    * attaches **metadata** (name, symbol, decimals) so the wrapped token displays correctly in wallets, explorers, and the dashboard, and
+    * makes the token **eligible for trading** in the on-chain liquidity pool.
+
+    Without registration the token still bridges and transfers normally — it simply shows with empty/default metadata until someone registers it. USDT and USDC are pre-registered.
+
+Registering a token records its metadata on-chain through a governance proposal. The Gonka consensus uses this metadata to label the wrapped CW-20 token contract.
+
+Because registration goes through a governance vote, it also acts as a lightweight **verification / anti-fraud step**: it is how the community vouches that a given Ethereum contract is the genuine token it claims to be, rather than a look-alike or invalid contract. A registered token is therefore a stronger signal of legitimacy (and a prerequisite for liquidity-pool trading), while an unregistered token still bridges but carries no such on-chain endorsement.
 
 This section walks you through drafting and submitting a governance proposal to register a new bridge token.
+
+!!! tip "Testnet first"
+    Register and test new tokens on **testnet** (chain ID `sepolia`) first. Promote a token to **mainnet** (chain ID `ethereum`) only once its bridging and metadata have been verified end-to-end. The mainnet rollout schedule for additional tokens is decided by governance.
 
 ### Prerequisites
 
@@ -138,4 +151,12 @@ Once a user bridges their tokens to the bridge contract on Ethereum, the Gonka c
 
 ```bash
 curl "https://node2.gonka.ai:8433/chain-api/productscience/inference/inference/wrapped_token_balances/{gonkaAddress}"
+```
+
+##### 3. One wrapped contract per token
+
+Each Ethereum token maps to exactly one wrapped CW-20 contract on Gonka. The first deposit instantiates it; every later deposit of the **same** token reuses the **same** contract, so all balances and transfers for that token live under one address. You can inspect a wrapped contract's transactions in the dashboard, e.g.:
+
+```text
+https://node1.gonka.ai:8443/dashboard/gonka/cosmwasm/105/transactions?contract=<wrappedContractAddress>
 ```

--- a/docs/cross-chain-transfers/ethereum-bridge/register-token.md
+++ b/docs/cross-chain-transfers/ethereum-bridge/register-token.md
@@ -1,5 +1,5 @@
 !!! warning
-    To avoid unintentional loss of tokens, do not use these instructions before the official announcement that the bridge is fully activated.
+    Always start with a small test transaction. Bridge transfers are irreversible, so before moving large amounts, send a small amount first and confirm it arrives as expected.
 
 The dedicated Bridge smart contract, controlled by the Gonka consensus, is active on Ethereum at the address:
 

--- a/docs/cross-chain-transfers/ethereum-bridge/tracker-integration.md
+++ b/docs/cross-chain-transfers/ethereum-bridge/tracker-integration.md
@@ -1,0 +1,101 @@
+!!! warning
+    Always start with a small test transaction. Bridge transfers are irreversible, so before moving large amounts, send a small amount first and confirm it arrives as expected.
+
+The dedicated Bridge smart contract, controlled by the Gonka consensus, is active on Ethereum at the address:
+
+```text
+0x972a7a92d92796a98801a8818bcf91f1648f2f68
+```
+
+---
+
+# Dashboard & tracker integration
+
+This page is for **dashboard, explorer, and tracker operators** who want to display or integrate Gonka bridge data themselves. All bridge state is readable from the public chain API — no special access is required.
+
+The examples below use `https://node2.gonka.ai:8443/chain-api/...`; you can point them at any node you trust.
+
+## End-user dashboard
+
+The hosted dashboard already exposes bridge functionality for end users — connecting an Ethereum wallet, deriving the matching `gonka1…` address (see [Addresses and keys](addresses-and-keys.md)), viewing wrapped balances, and driving deposits/withdrawals:
+
+```text
+https://node1.gonka.ai:8443/dashboard
+```
+
+Per-contract CosmWasm transaction history (useful for auditing a wrapped token) is available at:
+
+```text
+https://node1.gonka.ai:8443/dashboard/gonka/cosmwasm/105/transactions?contract=<wrappedContractAddress>
+```
+
+## Bridge contract addresses (per chain)
+
+The trusted bridge contract addresses Gonka accepts deposits from, by chain:
+
+```bash
+curl "https://node2.gonka.ai:8443/chain-api/productscience/inference/inference/bridge_addresses/ethereum"
+```
+
+## Bridge transactions
+
+List inbound bridge transactions (deposits/burns being validated and completed):
+
+```bash
+curl "https://node2.gonka.ai:8443/chain-api/productscience/inference/inference/bridge_transactions"
+```
+
+Look up a single transaction by its origin coordinates `(originChain, blockNumber, receiptIndex)`:
+
+```bash
+curl "https://node2.gonka.ai:8443/chain-api/productscience/inference/inference/bridge_transaction/ethereum/{blockNumber}/{receiptIndex}"
+```
+
+Each record carries `status` (`BRIDGE_PENDING` or `BRIDGE_COMPLETED`), the derived `ownerAddress` (the `gonka1…` recipient), `amount`, and the validating epoch — enough to track a transfer from "seen" to "completed".
+
+## Wrapped token balances for an address
+
+List all wrapped (CW-20) balances held by a Gonka address, with symbol, decimals, and a human-formatted balance:
+
+```bash
+curl "https://node2.gonka.ai:8443/chain-api/productscience/inference/inference/wrapped_token_balances/{gonkaAddress}"
+```
+
+## Token metadata
+
+Resolve the registered name/symbol/decimals for a bridged token by its source chain and Ethereum contract:
+
+```bash
+curl "https://node2.gonka.ai:8443/chain-api/productscience/inference/inference/token_metadata/ethereum/{ethereumContractAddress}"
+```
+
+!!! note
+    Metadata only exists for tokens that have been registered (see [Register a bridge token](register-token.md)). Unregistered tokens still bridge and appear in balances, but with empty/default metadata. Trackers should handle missing metadata gracefully and fall back to the raw contract address.
+
+## One wrapped contract per token
+
+Each Ethereum token maps to exactly **one** wrapped CW-20 contract on Gonka, keyed by `(chainId, ethereumContractAddress)`. The first deposit instantiates the contract; every later deposit of the same token reuses the same wrapped address. When indexing, treat the wrapped CW-20 contract address as the canonical on-Gonka identity for that Ethereum token.
+
+## Trading-related queries (liquidity pool)
+
+If you also surface trading data:
+
+```bash
+# Tokens approved for trading via the liquidity pool
+curl "https://node2.gonka.ai:8443/chain-api/productscience/inference/inference/approved_tokens_for_trade"
+
+# Validate that a CW-20 is an authorized wrapped token for trading
+curl "https://node2.gonka.ai:8443/chain-api/productscience/inference/inference/validate_wrapped_token_for_trade/{contractAddress}"
+
+# The singleton liquidity pool contract address / code id
+curl "https://node2.gonka.ai:8443/chain-api/productscience/inference/inference/liquidity_pool"
+```
+
+## Bridge service status
+
+The decentralized API exposes the bridge ingestion queue health, useful for an operations panel:
+
+```bash
+curl "https://node2.gonka.ai:8443/v1/bridge/status"
+curl "https://node2.gonka.ai:8443/v1/bridge/addresses?chain=ethereum"
+```

--- a/docs/cross-chain-transfers/ethereum-bridge/withdraw-gnk.md
+++ b/docs/cross-chain-transfers/ethereum-bridge/withdraw-gnk.md
@@ -1,0 +1,48 @@
+!!! warning
+    Always start with a small test transaction. Bridge transfers are irreversible, so before moving large amounts, send a small amount first and confirm it arrives as expected.
+
+The dedicated Bridge smart contract, controlled by the Gonka consensus, is active on Ethereum at the address:
+
+```text
+0x972a7a92d92796a98801a8818bcf91f1648f2f68
+```
+---
+
+# Withdraw GNK (Ethereum → Gonka)
+
+This is the reverse of [Deposit GNK (Gonka → Ethereum)](deposit-gnk.md). It burns wrapped GNK (**WGNK**) on Ethereum and releases the equivalent native **GNK** from escrow on Gonka.
+
+Native GNK is released to the Gonka address **derived from the same key that burns the WGNK** on Ethereum. Make sure you control that key on Gonka — see [Addresses and keys](addresses-and-keys.md).
+
+### A) Burn WGNK on Ethereum
+
+Burning is done by simply transferring WGNK to the bridge contract address. The bridge contract recognizes a transfer to itself as a burn and emits a `WGNKBurned` event.
+
+```javascript
+// WGNK is the bridge contract itself (it is both the bridge and the WGNK ERC-20)
+const tx = await wgnkContract.transfer(
+  "0x972a7a92d92796a98801a8818bcf91f1648f2f68",   // bridge / WGNK address
+  amountBN                                        // BigNumber amount (9 decimals)
+);
+await tx.wait();
+```
+
+!!! note
+    WGNK uses **9 decimals** to match the native GNK token.
+
+### B) Wait for Finalization
+
+The bridge only acts on **finalized** Ethereum blocks (about two epochs). Expect **15–20 minutes** between the burn being mined on Ethereum and the native GNK appearing on Gonka. No further action is required on the Ethereum side — once the burn is finalized, the Gonka consensus validates it and releases the escrowed GNK automatically.
+
+### C) Check Your GNK Balance on Gonka
+
+Query the native balance of the Gonka address derived from your key:
+
+```bash
+inferenced query bank balances <your_gonka_address> --node http://node1.gonka.ai:8000/chain-rpc/
+```
+
+You should see the released amount in `ngonka` (1 GNK = 10^9 ngonka).
+
+!!! tip
+    If the balance does not appear after ~20 minutes, confirm that the burn transaction was finalized on Ethereum and that you are querying the `gonka1…` address derived from the **same** key that signed the burn (not a seed-derived Gonka account — see [Addresses and keys](addresses-and-keys.md)).

--- a/docs/cross-chain-transfers/ethereum-bridge/withdraw-usdt.md
+++ b/docs/cross-chain-transfers/ethereum-bridge/withdraw-usdt.md
@@ -1,5 +1,5 @@
 !!! warning
-    To avoid unintentional loss of tokens, do not use these instructions before the official announcement that the bridge is fully activated.
+    Always start with a small test transaction. Bridge transfers are irreversible, so before moving large amounts, send a small amount first and confirm it arrives as expected.
 
 The dedicated Bridge smart contract, controlled by the Gonka consensus, is active on Ethereum at the address:
 

--- a/docs/cross-chain-transfers/ethereum-bridge/withdraw-usdt.md
+++ b/docs/cross-chain-transfers/ethereum-bridge/withdraw-usdt.md
@@ -10,6 +10,9 @@ The dedicated Bridge smart contract, controlled by the Gonka consensus, is activ
 
 # Withdraw USDT (Gonka → Ethereum)
 
+!!! note
+    Withdrawals are released on Ethereum by a BLS signature tied to the **current epoch's group key**, which is refreshed about once per day. A single epoch signature can authorize any number of withdrawals started in that epoch, so this step is normally fast. See [How Gonka → Ethereum is authorized](overview.md#how-gonka-ethereum-is-authorized-the-daily-group-key) for the background.
+
 ### A) Send Withdrawal Request on Gonka
 
 Initiate the withdrawal transaction using CLI:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,10 +43,14 @@ nav:
     - Cross-chain transfers:
       - Ethereum bridge:
         - Overview: cross-chain-transfers/ethereum-bridge/overview.md
+        - Addresses and keys: cross-chain-transfers/ethereum-bridge/addresses-and-keys.md
+        - Using the dashboard: cross-chain-transfers/ethereum-bridge/dashboard.md
         - Register a token: cross-chain-transfers/ethereum-bridge/register-token.md
         - Deposit USDT (Ethereum → Gonka): cross-chain-transfers/ethereum-bridge/deposit-usdt.md
         - Withdraw USDT (Gonka → Ethereum): cross-chain-transfers/ethereum-bridge/withdraw-usdt.md
         - Deposit GNK (Gonka → Ethereum): cross-chain-transfers/ethereum-bridge/deposit-gnk.md
+        - Withdraw GNK (Ethereum → Gonka): cross-chain-transfers/ethereum-bridge/withdraw-gnk.md
+        - Dashboard & tracker integration: cross-chain-transfers/ethereum-bridge/tracker-integration.md
       - IBC:
         - Withdraw USDT via Kava (Gonka → Ethereum): cross-chain-transfers/ibc/withdraw-usdt-via-kava.md
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,7 @@ nav:
     - Cross-chain transfers:
       - Ethereum bridge:
         - Overview: cross-chain-transfers/ethereum-bridge/overview.md
+        - Register a token: cross-chain-transfers/ethereum-bridge/register-token.md
         - Deposit USDT (Ethereum → Gonka): cross-chain-transfers/ethereum-bridge/deposit-usdt.md
         - Withdraw USDT (Gonka → Ethereum): cross-chain-transfers/ethereum-bridge/withdraw-usdt.md
         - Deposit GNK (Gonka → Ethereum): cross-chain-transfers/ethereum-bridge/deposit-gnk.md
@@ -189,6 +190,7 @@ plugins:
             "Withdraw USDT via Kava (Gonka → Ethereum)": "通过 Kava 提取 USDT（Gonka → 以太坊）"
             Overview: 概述
             Ethereum bridge: 以太坊跨链桥
+            Register a token: 注册代币
             "Deposit USDT (Ethereum → Gonka)": "存入 USDT（以太坊 → Gonka）"
             "Withdraw USDT (Gonka → Ethereum)": "提取 USDT（Gonka → 以太坊）"
             "Deposit GNK (Gonka → Ethereum)": "存入 GNK（Gonka → 以太坊）"


### PR DESCRIPTION
## Summary

Updates the Ethereum bridge documentation based on the engineering review and the team chat. Corrects the registration and ETH model, documents how a single key maps to both chains, and adds the missing user/operator guides.

### Corrections to existing pages
- **Registration is optional**: any ERC-20 bridges without a governance proposal; registration only adds metadata + trading eligibility, and acts as a lightweight anti-fraud / verification step. Replaced the old "must be registered" wording.
- **ETH is bridged as WETH**: the bridge tracks ERC-20 transfers (not native ETH), so ether is bridged by wrapping to WETH first. Removed the "send native ETH to the contract" flow.
- **One wrapped CW-20 per token** and **>50% host confirmation** made explicit.

### New conceptual sections in `overview.md`
- Daily epoch **group key** (chain of signatures) that authorizes Gonka → Ethereum transfers.
- **Timing & finalization** (Ethereum → Gonka ~15–20 min), **Bridge vs. exchange**, **Bridge vs. IBC**.

### New pages
- `addresses-and-keys.md` — one private key → two addresses, how the bridge derives the recipient, the seed-phrase pitfall (coin type 60 vs 118), and how to get the matching `gonka1…` address.
- `dashboard.md` — using the dashboard (derivation, mnemonic warning, deposit/withdraw incl. GNK↔WGNK).
- `withdraw-gnk.md` — WGNK (Ethereum) → native GNK (Gonka) return flow.
- `tracker-integration.md` — chain-API integration for explorer/tracker operators.

Nav updated with the new pages.

## Test plan
- [ ] `mkdocs build` succeeds with no broken internal links / nav entries
- [ ] Verify anchors resolve (`#timing-finalization`, `#how-gonka-ethereum-is-authorized-the-daily-group-key`)
- [ ] Eng review of the ETH-as-WETH change (confirm native ETH is not tracked)
- [ ] Eng review of the >50% host-weight and group-key wording

Made with [Cursor](https://cursor.com)