### PR TITLE
Bridge docs: fix dashboard URL trailing slash (QA-27/QA-28)

### DIFF
--- a/docs/cross-chain-transfers/ethereum-bridge/addresses-and-keys.md
+++ b/docs/cross-chain-transfers/ethereum-bridge/addresses-and-keys.md
@@ -62,7 +62,7 @@ The Gonka dashboard solves the derivation for you. Connect the **same Ethereum w
 Open the dashboard at:
 
 ```text
-https://node1.gonka.ai:8443/dashboard
+https://node1.gonka.ai:8443/dashboard/
 ```
 
 ### Option B — Import the same private key into the Gonka keyring

--- a/docs/cross-chain-transfers/ethereum-bridge/dashboard.md
+++ b/docs/cross-chain-transfers/ethereum-bridge/dashboard.md
@@ -14,7 +14,7 @@ The dedicated Bridge smart contract, controlled by the Gonka consensus, is activ
 The dashboard is the easiest way to bridge. It handles the key derivation for you (see [Addresses and keys](addresses-and-keys.md)), so you don't need to import private keys or compute addresses by hand. Open it at:
 
 ```text
-https://node1.gonka.ai:8443/dashboard
+https://node1.gonka.ai:8443/dashboard/
 ```
 
 ## What the dashboard does for you

--- a/docs/cross-chain-transfers/ethereum-bridge/tracker-integration.md
+++ b/docs/cross-chain-transfers/ethereum-bridge/tracker-integration.md
@@ -20,7 +20,7 @@ The examples below use `https://node2.gonka.ai:8443/chain-api/...`; you can poin
 The hosted dashboard already exposes bridge functionality for end users — connecting an Ethereum wallet, deriving the matching `gonka1…` address (see [Addresses and keys](addresses-and-keys.md)), viewing wrapped balances, and driving deposits/withdrawals:
 
 ```text
-https://node1.gonka.ai:8443/dashboard
+https://node1.gonka.ai:8443/dashboard/
 ```
 
 Per-contract CosmWasm transaction history (useful for auditing a wrapped token) is available at:


### PR DESCRIPTION
The documented dashboard URL `https://node1.gonka.ai:8443/dashboard` (no trailing slash) returns **HTTP 301** redirecting to `http://node1.gonka.ai:5173/dashboard/`, which is not reachable externally and times out. With the trailing slash, `https://node1.gonka.ai:8443/dashboard/` returns **HTTP 200**.

Fixes the three bare occurrences so the documented link works:
- `addresses-and-keys.md` (Option A)
- `dashboard.md`
- `tracker-integration.md`

The deeper `/dashboard/gonka/...` links already include the slash and are unchanged.