### PR TITLE
docs(en): use chain rpc for MiniMax intent

### DIFF
--- a/docs/host/minimax-bootstrap.md
+++ b/docs/host/minimax-bootstrap.md
@@ -79,7 +79,7 @@ MiniMax-M2.7 (FP8) requires **roughly 320 GB of total VRAM** per instance — a 
 #### 1. Send `PoCIntent` to the chain
 
 ```bash
-export NODE=https://node3.gonka.ai/
+export NODE=https://node3.gonka.ai/chain-rpc/
 ./inferenced tx inference declare-poc-intent MiniMaxAI/MiniMax-M2.7 \
   --from gonka-api-key \
   --node "$NODE" \


### PR DESCRIPTION
## What changed

Updated the MiniMax bootstrap `declare-poc-intent` example to use the public chain RPC path:

```bash
export NODE=https://node3.gonka.ai/chain-rpc/
```

## Why

The public HTTPS root for `node3.gonka.ai` serves the dashboard, while `inferenced --node` expects the Tendermint RPC endpoint.
