### PR TITLE
docs(governance): fix issues found verifying the governance pages (GON-39)

### DIFF
--- a/docs/governance/creating-proposals.md
+++ b/docs/governance/creating-proposals.md
@@ -57,6 +57,8 @@ Your proposal JSON `deposit` must satisfy `min_deposit` (same denom, amount >= m
 
 Prepare a gov v1 JSON (`messages`, `metadata`, `deposit`, `title`, `summary`).
 
+A proposal must carry either at least one message **or** a non-empty `metadata` field. A signaling proposal with an empty `messages` array and an empty `metadata` is rejected on submission (`either metadata or Msgs length must be non-nil`), so set `metadata` to a non-empty value in that case.
+
 There are two main parts to prepare:
 
 #### Proposal description fields

--- a/docs/governance/transactions-and-governance.md
+++ b/docs/governance/transactions-and-governance.md
@@ -10,7 +10,7 @@ Unordered transactions are supported and recommended here to avoid sequence cont
     - `--from <COLD_KEY_NAME>` → use your cold governance key.
     - `--keyring-backend file` → ensures signing with your local key (you will be prompted).
     - `--unordered --timeout-duration=60s` → makes the tx valid for a bounded time, bypassing sequence ordering (new in v0.53+).
-    - `--gas=2000000 --gas-adjustment=5.0` → manual gas setting with buffer.
+    - `--gas=2000000` → manual gas limit (a generous fixed value, enough for these txs). Note: `--gas-adjustment` only multiplies the estimate when `--gas auto` is used, so alongside a fixed `--gas` it is ignored and adds no buffer.
     - `--node <NODE_URL>/chain-rpc/` → required unless you run a local RPC node.
     - `--yes` → auto-approve broadcasting.
     

--- a/docs/governance/voting-power-eligibility.md
+++ b/docs/governance/voting-power-eligibility.md
@@ -55,12 +55,12 @@ guardian.tokens     = per_guardian_power                # original PoC weight is
 non_guardian.tokens = participant.weight                # unchanged
 ```
 
-**Effect:**
+**Effect (measured at each epoch transition):**
 
-- The combined Guardian share lands at `multiplier / (1 + multiplier) = 0.52 / 1.52 ≈ 34%` of total bonded.
-- Enough for veto (`>33%`), not enough to pass proposals (`>50%` required).
-- Cannot extract value or unilaterally change consensus, coordination among the Guardians is required for any action.
-- With 3 Guardians, each ends up with approximately `11.4%` of total bonded (`0.52 / (3 × 1.52)`).
+- At the instant the boost is applied, the combined Guardian share *targets* `multiplier / (1 + multiplier) = 0.52 / 1.52 ≈ 34%` of total bonded — about `11.4%` each with 3 Guardians (`0.52 / (3 × 1.52)`).
+- This `≈34%` is the level the formula reaches **when the boost runs**, not a fixed steady state. Guardian `tokens` are set once per epoch, so as the rest of the network's PoC weight grows the combined Guardian share drifts below 34%. On live mainnet at the time of writing the three Guardians sat at roughly `27%` combined (`~9%` each) — i.e. currently below the `>33%` veto line. Do not assume the Guardians continuously hold veto power.
+- The design intent is to keep the Guardians near veto strength (`>33%`) but below passing strength (`>50%`): enough to block a malicious proposal, never enough to pass one alone.
+- Cannot extract value or unilaterally change consensus — coordination among the Guardians is required for any action.
 
 ---
 
@@ -193,27 +193,35 @@ This delegation only allows voting on governance proposals. The grantee can stil
     
     
     # Vote using the file 
-    ./inferenced tx authz exec /tmp/authz-vote.json \  --from=<GRANTEE_KEY_NAME> \ 
-    --chain-id=gonka-mainnet \
-    --home .inference \
-    --keyring-backend file \
-    --node="<NODE_URL>/chain-rpc/" -y
+    ./inferenced tx authz exec /tmp/authz-vote.json \
+      --from=<GRANTEE_KEY_NAME> \
+      --chain-id=gonka-mainnet \
+      --home .inference \
+      --keyring-backend file \
+      --node="<NODE_URL>/chain-rpc/" -y
     ```
     
 === "Example response"
 
     ```
     {
-        "pagination": {
-            "total": "1"
-        },
-        "proposals": [
-            {
-                "id": "1"
-            }
-        ]
+        "height": "0",
+        "txhash": "C31311D9C43DD6F1DDE7CA143989A0551E3075C2FA0A2BB5F054A120AE552B2B",
+        "codespace": "",
+        "code": 0,
+        "data": "",
+        "raw_log": "",
+        "logs": [],
+        "info": "",
+        "gas_wanted": "0",
+        "gas_used": "0",
+        "tx": null,
+        "timestamp": "",
+        "events": []
     }
     ```
+
+    `code: 0` means the vote transaction was accepted — this is what tells you the vote went through. The CLI returns the broadcast receipt with the `txhash`; `height` is `0` until the tx is included in a block.
 
 ---
 


### PR DESCRIPTION
Follow-up to #1093. I verified the new governance pages against the chain/code and ran the create → submit → grant → delegated-vote flow end-to-end on a testnet to confirm what works. Everything held up — the Guardian formula, the 0.52 multiplier, the maturity thresholds (15M / 3M), the guardian addresses, and the veto/pass thresholds (33.4% / 50%) all match live values, and the cold-key→warm-key authz voting flow genuinely works (the delegated vote landed with the granter's full voting weight).

This PR fixes the issues that surfaced while doing that. Scope is deliberately limited to what was actually tested and found.

**`docs/governance/voting-power-eligibility.md`**
- **Guardian share framing.** The page stated the Guardians sit at "≈34% combined / 11.4% each." That's the level the boost *targets at an epoch transition*, not a steady state — the share decays as the rest of the network's PoC weight grows between transitions. On live mainnet the three Guardians currently sit at ~27% combined (~9% each), i.e. below the >33% veto line. Reworded so readers don't assume the Guardians continuously hold veto power.
- **Broken vote command.** The `tx authz exec` command had a stray `\` + spaces that broke the line continuation, so it could not be copy-pasted. Fixed.
- **Wrong "Example response."** The vote step showed a `gov proposals` list (output of a different command). Replaced with the real broadcast receipt; a `code: 0` receipt with a `txhash` is what confirms the vote was accepted.

**`docs/governance/transactions-and-governance.md`**
- **Misleading gas note.** `--gas=2000000 --gas-adjustment=5.0` was described as "manual gas setting with buffer." With a fixed `--gas`, `--gas-adjustment` is ignored (the CLI help states this, and it was confirmed live — `gas_wanted` stayed 2,000,000, not 10,000,000). Note corrected; the command examples are unchanged since the fixed value works fine.

**`docs/governance/creating-proposals.md`**
- **Metadata gap.** A no-message signaling proposal needs a non-empty `metadata`, otherwise submission is rejected (`either metadata or Msgs length must be non-nil`). Added a one-line note (hit this in practice on the first submit).

Resolves GON-39.