### PR TITLE
[codex] Refresh multi-model PoC docs for current mainnet params

### DIFF
--- a/docs/host/multi_model_poc.md
+++ b/docs/host/multi_model_poc.md
@@ -1,10 +1,20 @@
 # Multi-Model PoC — Host Operations Guide
 
-Upgrade v0.2.12 introduces multi-model Proof-of-Compute (PoC). 
+Multi-model Proof-of-Compute (PoC) arrived in v0.2.12 and expanded again in v0.2.13.
 
-## What changes in v0.2.12
+## What changed in v0.2.12 and v0.2.13
 
-Before v0.2.12, the network operated a single enforced model: `Qwen/Qwen3-235B-A22B-Instruct-2507-FP8`. After v0.2.12, the network can support multiple governance-approved models. Each model has its own PoC group, parameters, and weight contribution. Participation is tracked per model. The second model introduced with this upgrade is `moonshotai/Kimi-K2.6`; it has **passed bootstrap** and **participates in PoC** on mainnet alongside Qwen235B. Its coefficient is approximately 3.51× the coefficient of Qwen235B, based on relative compute complexity on the same hardware classes, including 8×H200 and 8×B200.
+Before v0.2.12, the network operated a single enforced model: `Qwen/Qwen3-235B-A22B-Instruct-2507-FP8`. v0.2.12 added `moonshotai/Kimi-K2.6` as the second governance-approved model and introduced per-model participation, delegation, and penalty timing. v0.2.13 recalibrated model coefficients and added `MiniMaxAI/MiniMax-M2.7` as the third governance-approved model.
+
+As of June 3, 2026 (mainnet epoch `285`), `poc_params.models` on mainnet contains:
+
+| `model_id` | Current mainnet status | `weight_scale_factor` | `penalty_start_epoch` |
+|---|---|---:|---:|
+| `Qwen/Qwen3-235B-A22B-Instruct-2507-FP8` | Active | `0.3593` | `0` |
+| `moonshotai/Kimi-K2.6` | Active | `0.78` | `251` |
+| `MiniMaxAI/MiniMax-M2.7` | Active | `0.3024` | `278` |
+
+These values are governance-controlled and can change. Before acting, always verify them with a live `params` query on the chain you use.
 
 ??? note "Why multi-model PoC works this way"
 
@@ -76,11 +86,11 @@ In most cases:
 
 ## Recommended actions
 
-If you are not running Kimi:
-    
-- If you operate multiple nodes and at least one runs Kimi: delegate to your own Kimi node
-- If you do not run Kimi at all: delegate to a host you trust
-- If you do not trust any delegate: use `refuse-poc-delegation`
+If you are not running a given model:
+
+- If you operate multiple nodes and at least one runs that model: delegate to your own node for that model
+- If you do not run that model at all: delegate to a host you trust
+- If you do not trust any delegate: use `refuse-poc-delegation` for that model
 
 Once `penalty_start_epoch` is reached for a model, not participating in that model directly or via valid delegation may reduce your consensus weight, depending on governance-configured parameters.
 

--- a/docs/release-announcements.md
+++ b/docs/release-announcements.md
@@ -348,7 +348,7 @@ If approved, the binary versions would be updated via the on-chain upgrade propo
 
 In case the proposal is approved, the following preparation is recommended.
 
-**`MiniMaxAI/MiniMax-M2.7` participation choice since epoch 271**
+**`MiniMaxAI/MiniMax-M2.7` participation choice by epoch 278**
 
 For each governance-approved model, multi-model PoC requires every host to explicitly choose participation (DIRECT / DELEGATE / REFUSE). Doing nothing after the model's `PenaltyStartEpoch` would result in a penalty. At this stage, you should decide your preferred option in advance so you are ready to act quickly if the proposal passes and the upgrade is successfully applied on mainnet.   
 

--- a/docs/zh/release-announcements.md
+++ b/docs/zh/release-announcements.md
@@ -335,7 +335,7 @@ PR 地址：[https://github.com/gonka-ai/gonka/pull/1143](https://github.com/gon
 
 如果提案获得批准，建议提前完成以下准备。
 
-**自 Epoch 271 起关于 `MiniMaxAI/MiniMax-M2.7` 的参与选择**
+**请在 Epoch 278 前完成 `MiniMaxAI/MiniMax-M2.7` 的参与选择**
 
 对于每个治理批准模型，多模型 PoC 要求每个 host 明确选择参与方式（DIRECT / DELEGATE / REFUSE）。 如果在模型的 `PenaltyStartEpoch` 之后未进行任何操作，将会受到惩罚。 因此，建议你提前决定首选方案，以便在提案通过并成功应用于主网后能够快速操作。
 


### PR DESCRIPTION
## What changed
- updated `docs/host/multi_model_poc.md` to reflect the current mainnet multi-model PoC state instead of the older Kimi-only snapshot
- added the live model roster and current `weight_scale_factor` / `penalty_start_epoch` values for Qwen, Kimi, and MiniMax
- generalized the host guidance from Kimi-specific wording to per-model wording
- corrected the stale MiniMax penalty-epoch wording in the English and Chinese release announcements

## Why
`GON-171` asked for the multi-model PoC docs to be refreshed after the v0.2.13 upgrade, including MiniMax and the current model coefficients.

While verifying the requested values, the live chain and the v0.2.13 source-of-truth showed that MiniMax `penalty_start_epoch` is `278`, not `271`, so the docs were updated to the live/current value instead of the stale number from the ticket text.

## Impact
Hosts reading the guide now see the current governance-approved model set and current on-chain parameters, and the release notes no longer contradict the live chain about when MiniMax penalties begin.

## Validation
- verified live chain params from `https://node3.gonka.ai/chain-api/productscience/inference/inference/params`
- built the docs site locally with `python -m mkdocs build -f mkdocs.docs.yml --strict` in a temporary virtualenv
