### PR TITLE
docs(bridge): add bridge epoch update guide

### DIFF
--- a/docs/cross-chain-transfers/ethereum-bridge/bridge-epoch-update.md
+++ b/docs/cross-chain-transfers/ethereum-bridge/bridge-epoch-update.md
@@ -1,0 +1,48 @@
+# Bridge epoch update
+
+Gonka &rarr; Ethereum transfers use a BLS signature from the current Gonka epoch. The Ethereum bridge contract must know the current epoch's group key before it can verify that signature and release funds on Ethereum.
+
+At the start of each epoch, about once per day, Gonka creates a new group key. A small Ethereum transaction registers that key on the bridge contract. Usually this is already done, but the bridge can briefly lag behind the Gonka chain just after an epoch change.
+
+## When you need this
+
+You may need an epoch update if a Gonka &rarr; Ethereum withdrawal or WGNK mint is ready, but Ethereum execution cannot proceed because the bridge is behind the chain.
+
+On the dashboard, this can appear as:
+
+```text
+A Bridge needs epoch update
+Bridge: Epoch 283 | Chain: Epoch 284 (1 behind)
+
+Withdrawals to Ethereum require the bridge to be synced to the current epoch.
+```
+
+If you see this, click **Update bridge** in the dashboard. Any user can submit the update. It is a normal Ethereum transaction, so the wallet that clicks the button pays Ethereum gas once for the update.
+
+## Manual update
+
+If you are not using the dashboard, submit each missing epoch in order:
+
+1. Check the latest epoch known by the Ethereum bridge contract.
+2. Start with `latest + 1`.
+3. Fetch the epoch data:
+
+```bash
+curl "https://node2.gonka.ai:8443/chain-api/productscience/inference/bls/epoch_data/<epochId>"
+```
+
+4. Use the returned `group_public_key` and `validation_signature` fields with the bridge update script:
+
+```bash
+HARDHAT_NETWORK=mainnet node submit-epoch-public.js \
+  0x972a7a92d92796a98801a8818bcf91f1648f2f68 \
+  <epochId> \
+  <group_public_key> \
+  <validation_signature>
+```
+
+5. Repeat for every missing epoch until the bridge epoch matches the chain epoch.
+6. Retry the withdrawal or WGNK mint execution on Ethereum.
+
+!!! note
+    The bridge contract only accepts the next sequential epoch key, signed by the previous epoch key. If the bridge is more than one epoch behind, submit the missing epochs one by one.

--- a/docs/cross-chain-transfers/ethereum-bridge/dashboard.md
+++ b/docs/cross-chain-transfers/ethereum-bridge/dashboard.md
@@ -23,6 +23,7 @@ https://node1.gonka.ai:8443/dashboard/
 * **Warns about seed-phrase accounts.** If you are using a wallet whose Ethereum and Gonka keys come from the same **mnemonic**, the dashboard detects this and warns you, because seed-derived accounts use different keys on each chain and would send funds to an address you don't control. Read [Addresses and keys](addresses-and-keys.md) for the full explanation.
 * **Shows your bridged balances** in a Bridge Assets section, so you can confirm a deposit arrived.
 * **Reports chain status**, so you can see if the chain is degraded before initiating a transfer.
+* **Prompts for bridge epoch updates** when the Ethereum bridge is behind the Gonka chain. If you see **A Bridge needs epoch update**, click **Update bridge** to submit the missing epoch key. This is a normal Ethereum transaction, so the connected wallet pays gas. See [Bridge epoch update](bridge-epoch-update.md).
 
 ## Supported flows
 

--- a/docs/cross-chain-transfers/ethereum-bridge/deposit-gnk.md
+++ b/docs/cross-chain-transfers/ethereum-bridge/deposit-gnk.md
@@ -75,6 +75,9 @@ curl "https://node2.gonka.ai:8443/v1/bls/signatures/<REQUEST_ID_HEX>" \
   '
 ```
 
+!!! tip "Bridge epoch update"
+    Before submitting the Ethereum mint transaction, make sure the Ethereum bridge contract is synced to `current_epoch_id`. If the dashboard shows **A Bridge needs epoch update** or the Ethereum execution fails with `InvalidEpoch`, follow [Bridge epoch update](bridge-epoch-update.md).
+
 ### C) Submit Mint Command on Ethereum
 
 Submit the mint command to the bridge contract on Ethereum using the [mint-wgnk.js](https://github.com/gonka-ai/gonka/blob/gm/contracts/proposals/ethereum-bridge-contact/mint-wgnk.js) script:

--- a/docs/cross-chain-transfers/ethereum-bridge/overview.md
+++ b/docs/cross-chain-transfers/ethereum-bridge/overview.md
@@ -84,7 +84,7 @@ Once the current epoch's group key is registered, withdrawals are fast: a **sing
 
 ### If the current epoch key isn't registered yet
 
-Withdrawals are signed with the current epoch's group key, and the bridge contract must already hold that key. Just after an epoch change (about daily) the contract can briefly lag, and your release will revert with `InvalidEpoch`. You do not have to wait — anyone can push the key. Fetch it from `https://node2.gonka.ai:8443/chain-api/productscience/inference/bls/epoch_data/<epochId>` (use the `group_public_key` and `validation_signature` fields) and submit it with `submit-epoch-public.js <bridge> <epochId> <group_public_key> <validation_signature>`. Submit any missing epochs in order (`latest + 1` first); it's a normal Ethereum transaction, so you just pay a usual amount of gas. Then retry your withdrawal.
+Withdrawals are signed with the current epoch's group key, and the bridge contract must already hold that key. Just after an epoch change (about daily) the contract can briefly lag, and your release may fail with `InvalidEpoch` or the dashboard may show that the bridge is behind the chain. You do not have to wait: anyone can push the missing key update, either from the dashboard or manually. See [Bridge epoch update](bridge-epoch-update.md).
 
 ## Timing & finalization
 
@@ -118,6 +118,7 @@ This bridge connects Gonka directly with **Ethereum**. Gonka also supports **IBC
 
 * [Addresses and keys](addresses-and-keys.md) — how a single private key controls both your Ethereum and Gonka addresses, and the seed-phrase pitfall.
 * [Using the dashboard](dashboard.md) — the easiest way to bridge, with no CLI or raw keys.
+* [Bridge epoch update](bridge-epoch-update.md) — what to do if the bridge is one or more epochs behind the Gonka chain.
 * [Deposit USDT (Ethereum → Gonka)](deposit-usdt.md) and [Withdraw USDT (Gonka → Ethereum)](withdraw-usdt.md) — bridging an ERC-20 both ways.
 * [Deposit GNK (Gonka → Ethereum)](deposit-gnk.md) and [Withdraw GNK (Ethereum → Gonka)](withdraw-gnk.md) — bridging native GNK both ways.
 * [Register a bridge token](register-token.md) — optional metadata/trading registration.

--- a/docs/cross-chain-transfers/ethereum-bridge/withdraw-usdt.md
+++ b/docs/cross-chain-transfers/ethereum-bridge/withdraw-usdt.md
@@ -80,6 +80,9 @@ The response includes:
 * `request_id`: The 32-byte hash used on Gonka.
 * `uncompressed_signature_128`: The BLS signature needed for Ethereum execution.
 
+!!! tip "Bridge epoch update"
+    Before submitting the Ethereum withdrawal transaction, make sure the Ethereum bridge contract is synced to `current_epoch_id`. If the dashboard shows **A Bridge needs epoch update** or the Ethereum execution fails with `InvalidEpoch`, follow [Bridge epoch update](bridge-epoch-update.md).
+
 ### D) Submit Withdrawal Command on Ethereum
 
 Use the [withdraw-tokens.js](https://github.com/gonka-ai/gonka/blob/gm/contracts/proposals/ethereum-bridge-contact/withdraw-tokens.js) script:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,6 +45,7 @@ nav:
         - Overview: cross-chain-transfers/ethereum-bridge/overview.md
         - Addresses and keys: cross-chain-transfers/ethereum-bridge/addresses-and-keys.md
         - Using the dashboard: cross-chain-transfers/ethereum-bridge/dashboard.md
+        - Bridge epoch update: cross-chain-transfers/ethereum-bridge/bridge-epoch-update.md
         - Register a token: cross-chain-transfers/ethereum-bridge/register-token.md
         - Deposit USDT (Ethereum → Gonka): cross-chain-transfers/ethereum-bridge/deposit-usdt.md
         - Withdraw USDT (Gonka → Ethereum): cross-chain-transfers/ethereum-bridge/withdraw-usdt.md


### PR DESCRIPTION
## Summary
- Add a short Bridge epoch update page explaining dashboard and manual update flows.
- Link the guide from the bridge overview, dashboard docs, and Gonka -> Ethereum BLS status steps.
- Add the new page to the Ethereum bridge navigation.

## Test plan
- `/Library/Frameworks/Python.framework/Versions/3.13/bin/mkdocs build --strict`


Made with [Cursor](https://cursor.com)