### PR TITLE
docs(governance): clarify voting tally rules

### DIFF
--- a/docs/governance/creating-proposals.md
+++ b/docs/governance/creating-proposals.md
@@ -40,18 +40,41 @@ chmod +x inferenced
 
 For detailed CLI installation instructions, see the [local machine CLI setup guide](https://gonka.ai/host/quickstart/#local-machine-install-the-cli-tool). After installing the CLI, you can return to this page and continue.
 
-### 2. Read `min_deposit` and `voting_period` from the chain
+### 2. Read governance parameters from the chain
 
-Do not rely on a fixed `ngonka` amount from old docs. Query live values:
+Do not rely on fixed numbers from old docs. Governance parameters are configurable on-chain, so query live values before drafting a proposal or announcing voting rules:
 
 ```bash
 ./inferenced query gov params \
   --node "<NODE_URL>/chain-rpc/" \
   --chain-id "<CHAIN_ID>" \
-  -o json | jq '{min_deposit: .params.min_deposit, voting_period: .params.voting_period}'
+  -o json | jq '.params | {
+      min_deposit,
+      expedited_min_deposit,
+      max_deposit_period,
+      voting_period,
+      expedited_voting_period,
+      quorum,
+      threshold,
+      expedited_threshold,
+      veto_threshold,
+      burn_vote_veto
+    }'
 ```
 
-Your proposal JSON `deposit` must satisfy `min_deposit` (same denom, amount >= minimum).
+Your proposal JSON `deposit` must satisfy `min_deposit` (same denom, amount >= minimum). If the proposal is expedited, check `expedited_min_deposit`, `expedited_voting_period`, and `expedited_threshold` as well.
+
+At the time of writing, mainnet uses:
+
+```text
+voting_period:            172800s   # 48 hours
+expedited_voting_period:  43200s    # 12 hours
+quorum:                   0.25
+threshold:                0.500000000000000000
+expedited_threshold:      0.667000000000000000
+veto_threshold:           0.334000000000000000
+burn_vote_veto:           true
+```
 
 ### 3. Proposal JSON
 
@@ -145,7 +168,7 @@ Share the proposal number so the community announcement can go out.
 
 ## Voting and tally
 
-Voting steps are documented on the dedicated page:
+Voting steps and result formulas are documented on the dedicated page:
 
 - [Voting on Proposals](https://gonka.ai/governance/voting-on-proposals/)
 
@@ -167,10 +190,21 @@ inferenced query auth module-accounts --node <NODE_URL>/chain-rpc/ | grep -B2 'n
 inferenced query inference params -o json --node <NODE_URL>/chain-rpc/ > current_params.json
 ```
 
-### 3. Check the minimum deposit
+### 3. Check governance deposit and tally parameters
 
 ```bash
-inferenced query gov params -o json --node <NODE_URL>/chain-rpc/ | jq '.params.min_deposit'
+inferenced query gov params -o json --node <NODE_URL>/chain-rpc/ \
+  | jq '.params | {
+      min_deposit,
+      expedited_min_deposit,
+      voting_period,
+      expedited_voting_period,
+      quorum,
+      threshold,
+      expedited_threshold,
+      veto_threshold,
+      burn_vote_veto
+    }'
 ```
 
 ### 4. Draft the proposal file

--- a/docs/governance/transactions-and-governance.md
+++ b/docs/governance/transactions-and-governance.md
@@ -41,6 +41,28 @@ Proposers are encouraged to discuss significant changes off-chain first (for exa
     - [Voting on Proposals](/governance/voting-on-proposals/)
     - [Voting Power, Eligibility, Delegation](/governance/voting-power-eligibility/)
 
+## Check Live Governance Parameters
+
+Governance parameters can be changed by successful proposals. Always query the chain for current values before preparing a proposal, publishing voting instructions, or explaining whether a proposal is likely to pass.
+
+```bash
+inferenced query gov params -o json --node <NODE_URL>/chain-rpc/ \
+  | jq '.params | {
+      min_deposit,
+      expedited_min_deposit,
+      max_deposit_period,
+      voting_period,
+      expedited_voting_period,
+      quorum,
+      threshold,
+      expedited_threshold,
+      veto_threshold,
+      burn_vote_veto
+    }'
+```
+
+At the time of writing, mainnet uses a 48-hour regular voting period, 12-hour expedited voting period, 25% quorum, >50% regular Yes threshold, >66.7% expedited Yes threshold, and >33.4% veto threshold.
+
 ## Track Proposal Status
 
 ```bash
@@ -52,6 +74,8 @@ inferenced query gov tally <VOTE_PROPOSAL_ID> -o json --node <NODE_URL>/chain-rp
 inferenced query gov proposals -o json --node <NODE_URL>/chain-rpc/
 ```
 ([docs.cosmos.network](https://docs.cosmos.network/sdk/v0.53/build/modules/gov/README))
+
+For the full quorum, threshold, veto, and `abstain` formulas, see [Voting on Proposals](/governance/voting-on-proposals/#how-the-result-is-counted).
 
 **You can also monitor governance via dashboards:**
 

--- a/docs/governance/voting-on-proposals.md
+++ b/docs/governance/voting-on-proposals.md
@@ -48,6 +48,112 @@ Confirm the **id**, **title**, **summary**, and (if present) **metadata** match 
     - **Flow:** proposals open (after deposit) -> voting period runs -> outcome decided by quorum/threshold/veto parameters -> if passed, messages execute via the gov module.
     - You may change your vote any time before voting period ends; the last vote counts.
 
+### Check current governance parameters
+
+Governance parameters are configurable on-chain. Do not rely on fixed numbers copied from older docs or announcements; query the live chain before recommending how participants should vote.
+
+```bash
+inferenced query gov params -o json --node <NODE_URL>/chain-rpc/ \
+  | jq '.params | {
+      voting_period,
+      expedited_voting_period,
+      quorum,
+      threshold,
+      expedited_threshold,
+      veto_threshold,
+      burn_vote_veto,
+      min_deposit,
+      expedited_min_deposit
+    }'
+```
+
+At the time of writing, mainnet parameters are:
+
+```text
+voting_period:            172800s   # 48 hours
+expedited_voting_period:  43200s    # 12 hours
+quorum:                   0.25
+threshold:                0.500000000000000000
+expedited_threshold:      0.667000000000000000
+veto_threshold:           0.334000000000000000
+burn_vote_veto:           true
+```
+
+### How the result is counted
+
+The tally uses PoC-weighted voting power. A proposal can pass only after quorum is reached:
+
+```text
+total_votes / total_bonded_voting_power >= quorum
+```
+
+Where:
+
+```text
+total_votes = Yes + No + NoWithVeto + Abstain
+non_abstain_votes = Yes + No + NoWithVeto
+```
+
+With current mainnet params, quorum is:
+
+```text
+total_votes / total_bonded_voting_power >= 0.25
+```
+
+After quorum, veto is checked before the pass threshold:
+
+```text
+NoWithVeto / (Yes + No + NoWithVeto + Abstain) > veto_threshold
+```
+
+With current mainnet params:
+
+```text
+NoWithVeto / total_votes > 0.334
+```
+
+If this condition is true, the proposal fails by veto. Since `burn_vote_veto` is currently `true`, a veto rejection burns the proposal deposit.
+
+Finally, the regular pass threshold is:
+
+```text
+Yes / (Yes + No + NoWithVeto) > threshold
+```
+
+With current mainnet params:
+
+```text
+Yes / non_abstain_votes > 0.5
+```
+
+For expedited proposals:
+
+```text
+Yes / non_abstain_votes > 0.667
+```
+
+### How `abstain` affects the result
+
+`abstain` is neutral, but it still affects the tally:
+
+- It counts toward quorum.
+- It is excluded from the Yes threshold denominator.
+- It is included in the veto denominator, so it pushes the veto ratio down.
+
+Important: `abstain` does **not** add to `no_with_veto`. The veto numerator is only `NoWithVeto`.
+
+Example:
+
+```text
+Yes = 40
+No = 0
+NoWithVeto = 20
+Abstain = 40
+
+veto ratio = 20 / 100 = 20%       # veto does not trigger
+pass ratio = 40 / 60 = 66.7%      # passes regular threshold
+```
+
 ### Cast (or change) your vote
 
 ```bash
@@ -66,21 +172,6 @@ inferenced tx gov vote <VOTE_PROPOSAL_ID> yes \
 inferenced query gov tally <VOTE_PROPOSAL_ID> -o json --node <NODE_URL>/chain-rpc/
 # Optional: list votes
 inferenced query gov votes <VOTE_PROPOSAL_ID> -o json --node <NODE_URL>/chain-rpc/
-```
-
-## Vote
-
-Again, this will need to be from you private machine with your Governance account:
-
-```bash
-# options: yes | no | no_with_veto | abstain
-inferenced tx gov vote <VOTE_PROPOSAL_ID> yes \
-  --from <COLD_KEY_NAME> \
-  --keyring-backend file \
-  --unordered --timeout-duration=60s \
-  --gas=2000000 --gas-adjustment=5.0 \
-  --node <NODE_URL>/chain-rpc/ \
-  --yes
 ```
 
 ---

--- a/docs/governance/voting-power-eligibility.md
+++ b/docs/governance/voting-power-eligibility.md
@@ -21,7 +21,7 @@ For the Genesis Guardians, an additional power-enhancement step is applied first
 
 ## Genesis Guardians
 
-A small set of bootstrap validators operated by the project team, hardcoded into chain params. They receive a temporary power boost so that their combined stake exceeds the 33% governance veto threshold.
+A small set of bootstrap validators operated by the project team, hardcoded into chain params. They receive a temporary power boost during the early network phase. The boost is configurable on-chain and has changed over time, so query live params before publishing exact Guardian voting-power numbers.
 
 ??? note "Current Genesis Guardian set on the live network"
     - `gonkavaloper1y2a9p56kv044327uycmqdexl7zs82fs5lyang5` (`gonka-1`)
@@ -36,7 +36,7 @@ Mechanism is documented in the official proposal:
 
 ???+ note "Purpose"
     - Prevent a 67% takeover of consensus during the early, low-stake phase.
-    - Block malicious governance proposals via the developer veto authority.
+    - Help block malicious governance proposals during bootstrap.
     - Provide rapid-response capability against protocol exploits.
     - Make cheap majority acquisition during bootstrap economically uninteresting.
 
@@ -48,18 +48,25 @@ Before `SetComputeValidators` runs, the inference module applies `applyEarlyNetw
 
 ```text
 other_total         = total_network_power − Σ guardian_original_power
-total_enhancement   = other_total × multiplier          # multiplier = 0.52
+total_enhancement   = other_total × multiplier
 per_guardian_power  = total_enhancement / guardian_count
 
 guardian.tokens     = per_guardian_power                # original PoC weight is REPLACED
 non_guardian.tokens = participant.weight                # unchanged
 ```
 
+As of the v0.2.13 upgrade, the configured multiplier is `0.33334`, which targets roughly `25%` combined Guardian power at the epoch transition where the boost is applied:
+
+```text
+guardian_share = multiplier / (1 + multiplier)
+guardian_share = 0.33334 / 1.33334 ≈ 25%
+```
+
 **Effect (measured at each epoch transition):**
 
-- At the instant the boost is applied, the combined Guardian share *targets* `multiplier / (1 + multiplier) = 0.52 / 1.52 ≈ 34%` of total bonded — about `11.4%` each with 3 Guardians (`0.52 / (3 × 1.52)`).
-- This `≈34%` is the level the formula reaches **when the boost runs**, not a fixed steady state. Guardian `tokens` are set once per epoch, so as the rest of the network's PoC weight grows the combined Guardian share drifts below 34%. On live mainnet at the time of writing the three Guardians sat at roughly `27%` combined (`~9%` each) — i.e. currently below the `>33%` veto line. Do not assume the Guardians continuously hold veto power.
-- The design intent is to keep the Guardians near veto strength (`>33%`) but below passing strength (`>50%`): enough to block a malicious proposal, never enough to pass one alone.
+- At the instant the boost is applied, the combined Guardian share targets `multiplier / (1 + multiplier)` of total bonded power.
+- This target is reached **when the boost runs**, not as a fixed steady state. Guardian `tokens` are set once per epoch, so as the rest of the network's PoC weight grows the combined Guardian share can drift between epoch transitions.
+- With the current `0.33334` multiplier, Guardians target roughly `25%` combined adjusted power, not enough to pass proposals alone and not enough to veto alone under the current `33.4%` veto threshold.
 - Cannot extract value or unilaterally change consensus — coordination among the Guardians is required for any action.
 
 ---
@@ -230,7 +237,7 @@ This delegation only allows voting on governance proposals. The grantee can stil
 | Status | Can vote? | Vote weight |
 |---|---|---|
 | Active participant, in epoch | Yes | `= participant.weight` |
-| Genesis Guardian, in epoch | Yes | `= (other_total × 0.52) / guardian_count` (boosted) |
+| Genesis Guardian, in epoch | Yes | `= (other_total × current_multiplier) / guardian_count` (boosted while early network protection is active) |
 | Failed PoC last epoch (INACTIVE) | No | `0` |
 | Failed CPoC, removed from epoch | No | `0` |
 | Jailed validator | No | `0` (until unjailed + re-bonded) |

--- a/docs/host/proposals.md
+++ b/docs/host/proposals.md
@@ -29,11 +29,25 @@ Governance power is earned through verifiable compute work, not passive coin own
 
 ### Key governance parameters
 
-| **Parameter**        | **Default**                                           | **Description**                                                                                                                                  | **Effect**                                                                                                          |
+| **Parameter**        | **Current mainnet value**                                           | **Description**                                                                                                                                  | **Effect**                                                                                                          |
 |-----------------------|-------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------|
-| **Quorum**            | 33.4% of total PoC-weighted power (governance-parameterized). | Minimum fraction of total active PoC-weighted voting power that must participate in a proposal for its result to be valid.                        | If quorum is not reached, the proposal is considered invalid regardless of its `Yes` / `No` outcome.                       |
-| **Majority Threshold**| >50% Yes votes (configurable on-chain).               | Minimum fraction of `Yes` votes among all cast votes (excluding `Abstain`) required for a proposal to pass. Voting weight is calculated proportionally to verified compute power from the most recent Sprint. | If this threshold is not met, the proposal is rejected even if quorum is achieved.                                   |
-| **Veto Threshold**    | 33.4% of the entire non-abstaining voting power in the system | If the fraction of `No_with_Veto` votes reaches this level, the proposal is forcefully rejected regardless of other votes.                            | Acts as a safeguard against malicious or harmful proposals, even if they have majority support.                        |
+| **Quorum**            | 25% of total bonded PoC-weighted voting power (governance-parameterized). | Minimum fraction of total bonded voting power that must participate in a proposal for its result to be valid. `Yes`, `No`, `NoWithVeto`, and `Abstain` all count toward quorum. | If quorum is not reached, the proposal is rejected regardless of its `Yes` / `No` outcome.                       |
+| **Majority Threshold**| >50% `Yes` votes for regular proposals; >66.7% for expedited proposals (configurable on-chain). | Minimum fraction of `Yes` votes among non-abstaining votes required for a proposal to pass: `Yes / (Yes + No + NoWithVeto)`. Voting weight is calculated proportionally to verified compute power. | If this threshold is not met, the proposal is rejected even if quorum is achieved.                                   |
+| **Veto Threshold**    | >33.4% `NoWithVeto` among all cast voting power, including `Abstain` in the denominator. | A veto rejection occurs when `NoWithVeto / (Yes + No + NoWithVeto + Abstain) > 0.334`. `Abstain` does not add to `NoWithVeto`; it only increases the denominator. | Acts as a safeguard against malicious or harmful proposals, even if they have majority support. A veto rejection currently burns the proposal deposit. |
 
-All these parameters are defined in the Genesis Code and can be modified via governance proposals, allowing the network to dynamically adjust decision-making rules over time.
-For on-chain governance steps, see [the detailed guide](https://gonka.ai/governance/transactions-and-governance/).
+All these parameters can be modified via governance proposals, allowing the network to dynamically adjust decision-making rules over time. Always query the live chain before announcing exact values:
+
+```bash
+inferenced query gov params -o json --node <NODE_URL>/chain-rpc/ \
+  | jq '.params | {
+      voting_period,
+      expedited_voting_period,
+      quorum,
+      threshold,
+      expedited_threshold,
+      veto_threshold,
+      burn_vote_veto
+    }'
+```
+
+For on-chain governance steps and full tally formulas, see [the detailed guide](https://gonka.ai/governance/transactions-and-governance/) and [Voting on Proposals](https://gonka.ai/governance/voting-on-proposals/).


### PR DESCRIPTION
## Summary
- Document live governance voting parameters, including quorum, regular/expedited thresholds, veto threshold, and deposit burn behavior.
- Add tally formulas for quorum, veto, pass threshold, and clarify how `abstain` affects each calculation.
- Refresh related governance and host proposal pages to point readers at live on-chain params instead of stale fixed values.

## Test plan
- Queried live mainnet governance params from node RPC/REST.
- Checked edited Markdown files with Cursor lints.
- Attempted `python3 -m mkdocs build -f mkdocs.docs.yml --strict`, but local environment is missing `mkdocs`.

Made with [Cursor](https://cursor.com)