### PR TITLE
docs: add Mingles gateway broker

### DIFF
--- a/docs/developer/quickstart.md
+++ b/docs/developer/quickstart.md
@@ -43,6 +43,7 @@ A broker is an independent operator who runs a Gonka gateway and resells inferen
 - [https://router.gonkascan.com/](https://router.gonkascan.com/)
 - [https://gonka-api.org/](https://gonka-api.org/)
 - [https://gonkabroker.com/](https://gonkabroker.com/)
+- [https://gonka-gateway.mingles.ai/](https://gonka-gateway.mingles.ai/)
 
 ??? note "About this list"
     Brokers listed here run a Gonka gateway against the mainnet and have agreed to public listing. Gonka does not endorse any specific broker. The list is displayed in a random order that is re-shuffled on every page load, so the position of each broker is not a ranking; please evaluate each operator on its own merits.

--- a/docs/zh/developer/quickstart.md
+++ b/docs/zh/developer/quickstart.md
@@ -43,6 +43,7 @@ name: index.md
 - [https://router.gonkascan.com/](https://router.gonkascan.com/)
 - [https://gonka-api.org/](https://gonka-api.org/)
 - [https://gonkabroker.com/](https://gonkabroker.com/)
+- [https://gonka-gateway.mingles.ai/](https://gonka-gateway.mingles.ai/)
 
 ??? note "关于此列表"
     此处列出的经纪商在主网上运行 Gonka gateway，并已同意被公开列出。Gonka 不为任何特定经纪商背书。列表会在每次页面加载时以随机顺序重新打乱，因此每家经纪商出现的位置不代表任何排名；请根据自身需求独立评估每家运营方。


### PR DESCRIPTION
## Summary
- Add `https://gonka-gateway.mingles.ai/` to the community broker list in the English developer quickstart.
- Mirror the same broker entry in the Chinese developer quickstart so both localized pages stay aligned.

## Test plan
- Checked IDE diagnostics for both edited Markdown files.


Made with [Cursor](https://cursor.com)