### PR TITLE
Update landing banner to list Kimi K2.6, MiniMax M2.7, Qwen3-235B

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -28,7 +28,7 @@ landing: true
     <!-- Banner -->
     <p class="gonka-banner">
       <span class="nowrap">Mainnet is live. </span>
-      <span class="nowrap">Qwen3-235B inference is now available. </span>
+      <span class="nowrap">Kimi K2.6, MiniMax M2.7, Qwen3-235B are now available. </span>
       <a class="nowrap" href="https://discord.com/invite/RADwCT2U6R">Join Discord.</a>
     </p>
     <!-- Hero -->

--- a/docs/zh/index.md
+++ b/docs/zh/index.md
@@ -29,7 +29,7 @@ landing: true
     <!-- Banner -->
     <p class="gonka-banner">
       <span class="nowrap">主网已上线。</span>
-      <span class="nowrap">Qwen3-235B 推理免费。</span>
+      <span class="nowrap">Kimi K2.6、MiniMax M2.7、Qwen3-235B 现已上线。</span>
       <a class="nowrap" href="https://discord.com/invite/RADwCT2U6R">加入 Discord</a>
     </p>
 


### PR DESCRIPTION
## Summary
- Update the homepage banner (EN + ZH) to announce three available models: Kimi K2.6, MiniMax M2.7, and Qwen3-235B

## Test plan
- [ ] Verify the English landing page displays the updated banner text
- [ ] Verify the Chinese landing page displays the updated banner text


Made with [Cursor](https://cursor.com)