### PR TITLE
fix: show all doc sections in mobile nav menu

### DIFF
--- a/buildtools/sync-docs-nav.py
+++ b/buildtools/sync-docs-nav.py
@@ -39,8 +39,7 @@ def transform_nav(nav: list) -> list:
     """Strip Home and remap Introduction for the docs build (recursive).
 
     The remap of ``Introduction: introduction.md`` -> ``Introduction: index.md``
-    is applied at any depth, because Introduction may live under a parent
-    section (e.g. ``Learn``) rather than at the top level.
+    is applied at any depth (top-level or nested).
     """
     out: list = []
     for item in nav:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,8 +8,9 @@ site_description: >-
 nav:
   - Home: index.md
 
+  - Introduction: introduction.md
+
   - Learn:
-    - Introduction: introduction.md
     - Architecture: architecture.md
     - Glossary: glossary.md
 


### PR DESCRIPTION
## Summary

- **Problem:** On mobile, tapping the hamburger menu on `/docs/` showed only the "Learn" section instead of the full documentation menu. This happened because the Introduction page (served at `/docs/`) was nested under the Learn section in `mkdocs.yml`, and MkDocs Material's mobile drawer opens to the current section level.
- **Fix:** Moved Introduction to the top level of the nav tree so that `/docs/` is a top-level page. Now the mobile drawer shows all sections (Learn, Developer, Host, Wallet, Governance, Reference, Resources) immediately.

## Test plan

- [ ] Open `gonka.ai/docs/` on a mobile device (or in a narrow browser viewport < 1220px)
- [ ] Tap the hamburger menu
- [ ] Verify all documentation sections are visible (not just Learn)
- [ ] Verify desktop sidebar still shows Introduction, Learn, Developer, Host, etc. correctly

Made with [Cursor](https://cursor.com)