### PR TITLE
Add community observability dashboards to Developer Quickstart

### DIFF
--- a/docs/assets/javascripts/links.js
+++ b/docs/assets/javascripts/links.js
@@ -17,7 +17,18 @@ document.addEventListener("DOMContentLoaded", function() {
   }
 
   shuffleBrokerList();
+  shuffleList(".broker-dashboards");
 });
+
+// Fisher-Yates shuffle for children of a container element.
+function shuffleChildren(container) {
+  const items = Array.from(container.children);
+  for (let i = items.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [items[i], items[j]] = [items[j], items[i]];
+  }
+  items.forEach((el) => container.appendChild(el));
+}
 
 // Shuffle the community broker list on the developer quickstart page so no
 // single broker is permanently displayed first. The list is identified by the
@@ -38,12 +49,12 @@ function shuffleBrokerList() {
   });
   if (targets.size === 0) return;
 
-  targets.forEach((ul) => {
-    const items = Array.from(ul.children);
-    for (let i = items.length - 1; i > 0; i--) {
-      const j = Math.floor(Math.random() * (i + 1));
-      [items[i], items[j]] = [items[j], items[i]];
-    }
-    items.forEach((li) => ul.appendChild(li));
+  targets.forEach((ul) => shuffleChildren(ul));
+}
+
+// Shuffle any list identified by CSS selector.
+function shuffleList(selector) {
+  document.querySelectorAll(selector).forEach((el) => {
+    if (el.children.length > 1) shuffleChildren(el);
   });
 }

--- a/docs/developer/quickstart.md
+++ b/docs/developer/quickstart.md
@@ -49,6 +49,17 @@ A broker is an independent operator who runs a Gonka gateway and resells inferen
 ??? note "About this list"
     This is a curated directory of community brokers that route inference through a public Gonka gateway and have agreed to be publicly listed. It is not exhaustive and does not endorse any operator. The list is displayed in a random order that is re-shuffled on every page load, so the position of each broker is not a ranking; please evaluate each operator on its own merits. This directory reflects an early bootstrap set. New operators who want to serve inference independently should see [Interested in operating a gateway?](#3-interested-in-operating-a-gateway). Some brokers provide a **▶ demo** link to a short onboarding screencast — style and length may vary.
 
+??? tip "Compare brokers — community observability dashboards"
+
+    Community members run independent monitoring probes against public broker endpoints and publish the results. These dashboards can help you compare uptime, latency, and pricing before choosing a broker:
+
+    <ul class="broker-dashboards">
+    <li><a href="https://meter.gonka.gg/">G-Meter</a> — network status overview</li>
+    <li><a href="https://power.gnk.space/">Gonka Power</a> — per-provider uptime, latency, throughput, context reliability, and estimated cost</li>
+    </ul>
+
+    These dashboards are **community-built tools, not part of the core protocol**. Data accuracy, methodology, and availability are the responsibility of each dashboard operator. Always verify critical metrics against your own testing. The list is displayed in a random order on every page load.
+
 ### 1.2 Get an API key
 
 Follow the onboarding instructions on the broker's site. Typically, you will:


### PR DESCRIPTION
## Summary

- Add collapsible **"Compare brokers — community observability dashboards"** section to Developer Quickstart, linking to [G-Meter](https://meter.gonka.gg/) and [Gonka Power](https://power.gnk.space/)
- Dashboard order is randomized on every page load (same principle as the broker list)
- Disclaimer: dashboards are community-built tools, not part of the core protocol
- Refactor shuffle logic into a shared `shuffleChildren()` helper to avoid code duplication

## Test plan

- [ ] `mkdocs serve` — expand the "Compare brokers" tip, verify both dashboard links render
- [ ] Refresh several times — dashboard order should change
- [ ] Verify disclaimer text does not reference any "team"

Made with [Cursor](https://cursor.com)