### PR TITLE
Fix contradictions and broken links in Wallet docs

### DIFF
--- a/docs/wallet/create-account.md
+++ b/docs/wallet/create-account.md
@@ -367,8 +367,8 @@ There are several ways to do this:
         Set the `NODE_URL` to one of the genesis nodes:
         ```bash title="Genesis Node List"
         http://36.189.234.237:17241
-        http://node1.gonka.ai:8443
-        http://node2.gonka.ai:8443
+        https://node1.gonka.ai:8443
+        https://node2.gonka.ai:8443
         http://47.236.26.199:8000
         http://47.236.19.22:18000
         http://gonka.spv.re:8000
@@ -377,11 +377,11 @@ There are several ways to do this:
     === "Current list of active participants"
         Alternatively, you can select a random active participant from the current epoch. Open the link or run the following command to fetch the list of active participants along with a cryptographic proof for verification:
         === "Link"
-            [http://node2.gonka.ai:8443/v1/epochs/current/participants](http://node2.gonka.ai:8000/v1/epochs/current/participants)
+            [https://node2.gonka.ai:8443/v1/epochs/current/participants](https://node2.gonka.ai:8443/v1/epochs/current/participants)
     
         === "Command"
             ```bash
-            curl http://node2.gonka.ai:8443/v1/epochs/current/participants
+            curl https://node2.gonka.ai:8443/v1/epochs/current/participants
             ```
         
     Download the `inferenced` CLI tool (the latest `inferenced` binary for your system is [here](https://github.com/gonka-ai/gonka/releases)).

--- a/docs/wallet/dashboard.md
+++ b/docs/wallet/dashboard.md
@@ -41,7 +41,7 @@ You can interact with the dashboard in two ways:
     To unlock the full functionality of the dashboard, you need a Gonka account.
     
     - Already have one? Proceed to the ["Set Up External Wallet"](https://gonka.ai/wallet/dashboard/#2-set-up-external-wallet) section below.
-    - New user? Visit [the Developer](https://gonka.ai/developer/quickstart/){target=_blank} or [Host](https://gonka.ai/host/quickstart/){target=_blank} Quickstart to create an account.
+    - New user? [Create a Gonka account](https://gonka.ai/wallet/create-account/) first, then return here.
     
     ### 2. Set Up External Wallet
     To interact with Dashboard through your wallet, it is recommended to use [Keplr](https://www.keplr.app/){target=_blank} (a browser extension wallet built for Cosmos-based chains).
@@ -49,7 +49,7 @@ You can interact with the dashboard in two ways:
     ??? note "What is a wallet?"
         A crypto wallet serves as a secure container for a user's public and private cryptographic keys, enabling them to manage, transfer, and purchase cryptocurrencies. Gonka is built on the Cosmos-SDK blockchain framework and can be accessed using Keplr wallet.
         
-    - If you have a Keplr wallet browser extention, proceed to the ["Connect wallet"](https://gonka.ai/wallet/dashboard/#3-connect-wallet) section.
+    - If you have a Keplr wallet browser extension, proceed to the ["Connect wallet"](https://gonka.ai/wallet/dashboard/#3-connect-wallet) section.
     - If you haven't set it up yet, follow the steps below.
     
     Install an extension for your browser.
@@ -77,7 +77,7 @@ You can interact with the dashboard in two ways:
     <a href="/images/keplr_extension.png" target="_blank"><img src="/images/keplr_extension.png" style="width:500px; height:auto;"></a>
 
     At this point, the extension is installed, but not yet connected to your wallet. 
-    Next, open the extension and log in to your wallet. Once you are logged in, follow the steps below to  and continue with the setup process.
+    Next, open the extension and log in to your wallet. Once you are logged in, follow the steps below to continue with the setup process.
 
     Click "Import an Existing Wallet".
                         
@@ -89,17 +89,13 @@ You can interact with the dashboard in two ways:
                 
     Paste your private key.
     
-    ??? note "Important note on wallet-bridge compatibility. Please read carefully  if you intend to sell Gonka coins via the Ethereum bridge in the future"
-        An Ethereum bridge is a system that lets you securely move assets or data between Ethereum and another blockchain, locking coins on one chain and minting or releasing equivalent coins on the other. Essentially, it’s the mechanism you need if you want to sell, trade, or use coins from another chain within the Ethereum ecosystem. 
-                        
-        Eligible (you can export/use a raw private key):
-                        
-        - Accounts created via `inferenced` CLI tool
-        - Accounts created via the “Connect with Google” flow in Keplr
-                    
-        Not eligible (no private key export):
-                        
-        - Keplr wallets created from a recovery phrase. Keplr does not export the private key, so avoid creating mnemonic-based wallets there if bridge compatibility matters.
+    ??? note "Important note on wallet-bridge compatibility"
+        The bridge currently expects a specific account setup. Some wallets may let you create a Gonka account and even export a private key, but that does not always mean the account will work correctly with the bridge. For bridge use, please create your Gonka account in one of the following ways:
+
+        - With the `inferenced` CLI tool
+        - In Keplr using the “Connect with Google” flow
+        
+        These are the recommended and supported options for users who need Ethereum bridge compatibility. See [Create a Gonka account](https://gonka.ai/wallet/create-account/) for details.
                 
         <a href="/images/dashboard_ping_pub_3_5_4.png" target="_blank"><img src="/images/dashboard_keplr_step_3_5_5_private_key.png" style="width:500px; height:auto;"></a>
                         
@@ -155,17 +151,13 @@ You can interact with the dashboard in two ways:
                 
         Paste your private key.
     
-        ??? note "Important note on wallet-bridge compatibility. Please read carefully  if you intend to sell Gonka coins via the Ethereum bridge in the future"
-            An Ethereum bridge is a system that lets you securely move assets or data between Ethereum and another blockchain, locking coins on one chain and minting or releasing equivalent coins on the other. Essentially, it’s the mechanism you need if you want to sell, trade, or use coins from another chain within the Ethereum ecosystem. At the moment, there is no bridge to Ethereum on Gonka. Any future deployment of such a bridge would require on-chain governance approval. If an Ethereum bridge is approved by on-chain governance, only accounts with a raw private key are expected to be eligible.
-                        
-            Eligible (you can export/use a raw private key):
-                        
-            - Accounts created via `inferenced` CLI tool
-            - Accounts created via the “Connect with Google” flow in Keplr
-                    
-            Not eligible (no private key export):
-                        
-            - Keplr wallets created from a recovery phrase. Keplr does not export the private key, so avoid creating mnemonic-based wallets there if future bridge compatibility matters.
+        ??? note "Important note on wallet-bridge compatibility"
+            The bridge currently expects a specific account setup. Some wallets may let you create a Gonka account and even export a private key, but that does not always mean the account will work correctly with the bridge. For bridge use, please create your Gonka account in one of the following ways:
+
+            - With the `inferenced` CLI tool
+            - In Keplr using the “Connect with Google” flow
+            
+            These are the recommended and supported options for users who need Ethereum bridge compatibility. See [Create a Gonka account](https://gonka.ai/wallet/create-account/) for details.
                 
         <a href="/images/dashboard_ping_pub_3_5_4.png" target="_blank"><img src="/images/dashboard_keplr_step_3_5_5_private_key.png" style="width:450px; height:auto;"></a>
                         


### PR DESCRIPTION
## Summary

- **Remove false "no bridge exists" statement** from `dashboard.md` — it claimed "there is no bridge to Ethereum on Gonka" while the entire `ethereum-bridge/` section documents an active, CertiK-audited bridge contract
- **Align bridge-compatibility warnings** in `dashboard.md` with the canonical wording from `create-account.md`
- **Fix account creation link** in Dashboard Full Mode — now points to `wallet/create-account` instead of Developer/Host Quickstart
- **Fix genesis node URLs** in `create-account.md` — `node1.gonka.ai:8443` and `node2.gonka.ai:8443` now use `https://` (port 8443 implies TLS)
- **Fix participants link mismatch** — display text showed `:8443` but href pointed to `:8000`
- **Fix typo** "extention" → "extension" and broken sentence fragment

## Test plan

- [ ] Verify all genesis node URLs resolve correctly with `https://`
- [ ] Verify `wallet/create-account` link works from Dashboard Full Mode
- [ ] Confirm bridge-compatibility notes in `dashboard.md` render correctly in MkDocs
- [ ] Spot-check no other pages reference the removed "no bridge exists" wording


Made with [Cursor](https://cursor.com)