### PR TITLE
docs(governance): update min deposit to 500 GNK per community vote

### DIFF
--- a/docs/cross-chain-transfers/ethereum-bridge/register-token.md
+++ b/docs/cross-chain-transfers/ethereum-bridge/register-token.md
@@ -71,7 +71,7 @@ Create a file named `register_token_proposal.json`. This proposal will include t
     }
   ],
   "metadata": "ipfs://CID",
-  "deposit": "10000000ngonka",
+  "deposit": "500000000000ngonka",
   "title": "Register Wrapped SYMBOL Token Metadata",
   "summary": "This proposal registers the metadata for the SYMBOL ERC-20 token bridged from Ethereum on the Gonka chain."
 }
@@ -112,7 +112,7 @@ inferenced query gov proposals --node $SEED_URL/chain-rpc/
 If your initial deposit was below the minimum required to enter the voting period, top it up:
 
 ```bash
-inferenced tx gov deposit <proposal_id> 10000000ngonka \
+inferenced tx gov deposit <proposal_id> 500000000000ngonka \
   --from <cold-key-name> \
   --keyring-backend file \
   --unordered --timeout-duration=60s \

--- a/docs/governance/creating-proposals.md
+++ b/docs/governance/creating-proposals.md
@@ -67,6 +67,9 @@ Your proposal JSON `deposit` must satisfy `min_deposit` (same denom, amount >= m
 At the time of writing, mainnet uses:
 
 ```text
+min_deposit:              500000000000ngonka   # 500 GNK
+expedited_min_deposit:    1000000000000ngonka  # 1000 GNK
+max_deposit_period:       86400s    # 24 hours
 voting_period:            172800s   # 48 hours
 expedited_voting_period:  43200s    # 12 hours
 quorum:                   0.25

--- a/docs/governance/transactions-and-governance.md
+++ b/docs/governance/transactions-and-governance.md
@@ -61,7 +61,7 @@ inferenced query gov params -o json --node <NODE_URL>/chain-rpc/ \
     }'
 ```
 
-At the time of writing, mainnet uses a 48-hour regular voting period, 12-hour expedited voting period, 25% quorum, >50% regular Yes threshold, >66.7% expedited Yes threshold, and >33.4% veto threshold.
+At the time of writing, mainnet uses a 48-hour regular voting period, 12-hour expedited voting period, 25% quorum, >50% regular Yes threshold, >66.7% expedited Yes threshold, >33.4% veto threshold, 500 GNK minimum deposit for regular proposals, and 1000 GNK minimum deposit for expedited proposals.
 
 ## Track Proposal Status
 

--- a/docs/governance/voting-on-proposals.md
+++ b/docs/governance/voting-on-proposals.md
@@ -70,6 +70,9 @@ inferenced query gov params -o json --node <NODE_URL>/chain-rpc/ \
 At the time of writing, mainnet parameters are:
 
 ```text
+min_deposit:              500000000000ngonka   # 500 GNK
+expedited_min_deposit:    1000000000000ngonka  # 1000 GNK
+max_deposit_period:       86400s    # 24 hours
 voting_period:            172800s   # 48 hours
 expedited_voting_period:  43200s    # 12 hours
 quorum:                   0.25

--- a/docs/host/proposals.md
+++ b/docs/host/proposals.md
@@ -31,6 +31,7 @@ Governance power is earned through verifiable compute work, not passive coin own
 
 | **Parameter**        | **Current mainnet value**                                           | **Description**                                                                                                                                  | **Effect**                                                                                                          |
 |-----------------------|-------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------|
+| **Min Deposit**       | 500 GNK (500,000,000,000 ngonka) for regular proposals; 1000 GNK (1,000,000,000,000 ngonka) for expedited proposals. | Minimum deposit required to submit a governance proposal and move it into the voting period. | If the deposit is not met within the max deposit period, the proposal is removed without entering voting. |
 | **Quorum**            | 25% of total bonded PoC-weighted voting power (governance-parameterized). | Minimum fraction of total bonded voting power that must participate in a proposal for its result to be valid. `Yes`, `No`, `NoWithVeto`, and `Abstain` all count toward quorum. | If quorum is not reached, the proposal is rejected regardless of its `Yes` / `No` outcome.                       |
 | **Majority Threshold**| >50% `Yes` votes for regular proposals; >66.7% for expedited proposals (configurable on-chain). | Minimum fraction of `Yes` votes among non-abstaining votes required for a proposal to pass: `Yes / (Yes + No + NoWithVeto)`. Voting weight is calculated proportionally to verified compute power. | If this threshold is not met, the proposal is rejected even if quorum is achieved.                                   |
 | **Veto Threshold**    | >33.4% `NoWithVeto` among all cast voting power, including `Abstain` in the denominator. | A veto rejection occurs when `NoWithVeto / (Yes + No + NoWithVeto + Abstain) > 0.334`. `Abstain` does not add to `NoWithVeto`; it only increases the denominator. | Acts as a safeguard against malicious or harmful proposals, even if they have majority support. A veto rejection currently burns the proposal deposit. |
@@ -40,6 +41,8 @@ All these parameters can be modified via governance proposals, allowing the netw
 ```bash
 inferenced query gov params -o json --node <NODE_URL>/chain-rpc/ \
   | jq '.params | {
+      min_deposit,
+      expedited_min_deposit,
       voting_period,
       expedited_voting_period,
       quorum,

--- a/docs/zh/cross-chain-transfers/ethereum-bridge/register-token.md
+++ b/docs/zh/cross-chain-transfers/ethereum-bridge/register-token.md
@@ -58,7 +58,7 @@ inferenced query auth module-accounts --node $SEED_URL/chain-rpc/ | grep -B2 'na
     }
   ],
   "metadata": "ipfs://CID",
-  "deposit": "10000000ngonka",
+  "deposit": "500000000000ngonka",
   "title": "Register Wrapped SYMBOL Token Metadata",
   "summary": "This proposal registers the metadata for the SYMBOL ERC-20 token bridged from Ethereum on the Gonka chain."
 }
@@ -99,7 +99,7 @@ inferenced query gov proposals --node $SEED_URL/chain-rpc/
 如果您的初始存款低于进入投票期所需的最低金额，请进行追加：
 
 ```bash
-inferenced tx gov deposit <proposal_id> 10000000ngonka \
+inferenced tx gov deposit <proposal_id> 500000000000ngonka \
   --from <cold-key-name> \
   --keyring-backend file \
   --unordered --timeout-duration=60s \

--- a/docs/zh/transactions-and-governance.md
+++ b/docs/zh/transactions-and-governance.md
@@ -145,7 +145,7 @@ inferenced tx gov draft-proposal
     }
   ],
   "metadata": "ipfs://CID",  // 托管在 IPFS 上的元数据文件路径
-  "deposit": "10000000ngonka",               // 满足 min_deposit
+  "deposit": "500000000000ngonka",               // 满足 min_deposit
   "title": "调整 epoch 长度",
   "summary": "将 epoch 长度增加到 1000"
 }


### PR DESCRIPTION
## Summary

- Updated minimum governance proposal deposit from 10 GNK to **500 GNK** (500,000,000,000 ngonka) and expedited minimum deposit to **1000 GNK** (1,000,000,000,000 ngonka) per passed community governance vote.
- Added `min_deposit`, `expedited_min_deposit`, and `max_deposit_period` to "at the time of writing" parameter blocks across governance docs.
- Updated example deposit amounts in proposal JSON templates and CLI commands (EN + ZH).
- Added **Min Deposit** row to the key governance parameters table in `docs/host/proposals.md`.

## Files changed

- `docs/governance/creating-proposals.md`
- `docs/governance/voting-on-proposals.md`
- `docs/governance/transactions-and-governance.md`
- `docs/host/proposals.md`
- `docs/cross-chain-transfers/ethereum-bridge/register-token.md`
- `docs/zh/cross-chain-transfers/ethereum-bridge/register-token.md`
- `docs/zh/transactions-and-governance.md`

## Test plan

- [ ] Verify all deposit values render correctly on the docs site
- [ ] Confirm jq query examples include `min_deposit` and `expedited_min_deposit`
- [ ] Check that example proposal JSONs use the correct `500000000000ngonka` deposit


Made with [Cursor](https://cursor.com)