### PR TITLE
docs(quickstart): add demo screencast link for Mingles Router broker

### DIFF
--- a/docs/developer/quickstart.md
+++ b/docs/developer/quickstart.md
@@ -43,7 +43,7 @@ A broker is an independent operator who runs a Gonka gateway and resells inferen
 - [https://router.gonkascan.com/](https://router.gonkascan.com/) · [▶ demo](https://youtu.be/1uWmLGPoBCM)
 - [https://gonka-api.org/](https://gonka-api.org/)
 - [https://gonkabroker.com/](https://gonkabroker.com/)
-- [https://gonka-gateway.mingles.ai/](https://gonka-gateway.mingles.ai/)
+- [https://gonka-gateway.mingles.ai/](https://gonka-gateway.mingles.ai/) · [▶ demo](https://youtu.be/gegiRnNMavY)
 - [https://console.hyperfusion.io/](https://console.hyperfusion.io/) 
 
 ??? note "About this list"

--- a/docs/zh/developer/quickstart.md
+++ b/docs/zh/developer/quickstart.md
@@ -43,7 +43,7 @@ name: index.md
 - [https://router.gonkascan.com/](https://router.gonkascan.com/)
 - [https://gonka-api.org/](https://gonka-api.org/)
 - [https://gonkabroker.com/](https://gonkabroker.com/)
-- [https://gonka-gateway.mingles.ai/](https://gonka-gateway.mingles.ai/)
+- [https://gonka-gateway.mingles.ai/](https://gonka-gateway.mingles.ai/) · [▶ demo](https://youtu.be/gegiRnNMavY)
 - [https://console.hyperfusion.io/](https://console.hyperfusion.io/)
 
 ??? note "关于此列表"


### PR DESCRIPTION
## Summary
- Add ▶ demo link ([YouTube](https://youtu.be/gegiRnNMavY)) to the Mingles Router (`gonka-gateway.mingles.ai`) entry in the developer quickstart broker list
- Updated both EN (`docs/developer/quickstart.md`) and ZH (`docs/zh/developer/quickstart.md`) versions

## Test plan
- [ ] Verify the demo link renders correctly on the developer quickstart page
- [ ] Confirm the YouTube video loads when clicking the link


Made with [Cursor](https://cursor.com)