### PR TITLE
docs(wallet): add Cosmostation/Fox Wallet flows for existing users, fix bridge compatibility notes

### DIFF
--- a/docs/wallet/create-account.md
+++ b/docs/wallet/create-account.md
@@ -3,16 +3,16 @@
 To start using Gonka Network, you first need to create a Gonka Account.
 There are several ways to do this:
 
-- Via external wallet (Keplr)
+- Via external wallet (Keplr, Cosmostation, Fox Wallet)
 - Via `inferenced` CLI tool
 
-!!! note "Important note on wallet-bridge compatibility. Please read carefully  if you intend to sell Gonka coins via the Ethereum bridge"
-    The bridge currently expects a specific account setup. Some wallets may let you create a Gonka account and even export a private key, but that does not always mean the account will work correctly with the bridge. For bridge use, please create your Gonka account in one of the following ways:
+!!! note "Bridge compatibility and seed (mnemonic) phrases"
+    If you create your Gonka account using a **mnemonic (seed) phrase** — as Cosmostation and Fox Wallet do by default — the account **is compatible** with the Ethereum bridge, but the bridge will deliver tokens to a different `gonka1…` address than the one your wallet displays. This happens because Ethereum and Gonka use different BIP-44 derivation paths (coin type `60` vs `118`), so the same seed phrase produces different private keys on each chain. You still control those funds and can access them with an extra derivation step. See [Addresses and keys](../cross-chain-transfers/ethereum-bridge/addresses-and-keys.md) for a full explanation.
+
+    For the simplest bridge experience — where your wallet automatically shows the address the bridge uses and no extra derivation step is needed — create your Gonka account in one of the following ways:
 
     - With the `inferenced` CLI tool
     - In Keplr using the “Connect with Google” flow
-    
-    These are the recommended and supported options for users who need Ethereum bridge compatibility.
 
 === "External wallet"
 
@@ -35,12 +35,8 @@ There are several ways to do this:
             Click "Connect with Google". Follow the instructions to sign in via Gmail.
 
             ??? note "Important note on wallet-bridge compatibility. Please read carefully  if you intend to sell Gonka coins via the Ethereum bridge"
-                The bridge currently expects a specific account setup. Some wallets may let you create a Gonka account and even export a private key, but that does not always mean the account will work correctly with the bridge. For bridge use, please create your Gonka account in one of the following ways:
+                If your wallet was created using a **mnemonic (seed) phrase**, the account is compatible with the Ethereum bridge but requires extra steps — the bridge will deliver tokens to a different `gonka1…` address than the one your wallet shows. You still control those funds and can access them by deriving the correct key. See [Addresses and keys](../cross-chain-transfers/ethereum-bridge/addresses-and-keys.md) for details. For the simplest bridge experience, create your Gonka account via the `inferenced` CLI or Keplr “Connect with Google” flow.
 
-                - With the `inferenced` CLI tool
-                - In Keplr using the “Connect with Google” flow
-                
-                These are the recommended and supported options for users who need Ethereum bridge compatibility.
                 
             <a href="/images/keplr_mobile_recovery_phrase.PNG" target="_blank"><img src="/images/keplr_mobile_recovery_phrase.PNG" style="width:auto; height:337.5px;"></a>
                 
@@ -99,12 +95,8 @@ There are several ways to do this:
             Click "Connect with Google". Follow the instructions to sign in via Gmail.
 
             ??? note "Important note on wallet-bridge compatibility. Please read carefully  if you intend to sell Gonka coins via the Ethereum bridge"
-                The bridge currently expects a specific account setup. Some wallets may let you create a Gonka account and even export a private key, but that does not always mean the account will work correctly with the bridge. For bridge use, please create your Gonka account in one of the following ways:
+                If your wallet was created using a **mnemonic (seed) phrase**, the account is compatible with the Ethereum bridge but requires extra steps — the bridge will deliver tokens to a different `gonka1…` address than the one your wallet shows. You still control those funds and can access them by deriving the correct key. See [Addresses and keys](../cross-chain-transfers/ethereum-bridge/addresses-and-keys.md) for details. For the simplest bridge experience, create your Gonka account via the `inferenced` CLI or Keplr “Connect with Google” flow.
 
-                - With the `inferenced` CLI tool
-                - In Keplr using the “Connect with Google” flow
-                
-                These are the recommended and supported options for users who need Ethereum bridge compatibility.
                 
             <a href="/images/keplr_welcome_to_keplr.png" target="_blank"><img src="/images/keplr_welcome_to_keplr.png" style="width:500px; height:auto;"></a>
                 
@@ -156,12 +148,8 @@ There are several ways to do this:
                 Paste your private key.
 
                 ??? note "Important note on wallet-bridge compatibility. Please read carefully  if you intend to sell Gonka coins via the Ethereum bridge"
-                    The bridge currently expects a specific account setup. Some wallets may let you create a Gonka account and even export a private key, but that does not always mean the account will work correctly with the bridge. For bridge use, please create your Gonka account in one of the following ways:
+                    If your wallet was created using a **mnemonic (seed) phrase**, the account is compatible with the Ethereum bridge but requires extra steps — the bridge will deliver tokens to a different `gonka1…` address than the one your wallet shows. You still control those funds and can access them by deriving the correct key. See [Addresses and keys](../cross-chain-transfers/ethereum-bridge/addresses-and-keys.md) for details. For the simplest bridge experience, create your Gonka account via the `inferenced` CLI or Keplr “Connect with Google” flow.
 
-                    - With the `inferenced` CLI tool
-                    - In Keplr using the “Connect with Google” flow
-                    
-                    These are the recommended and supported options for users who need Ethereum bridge compatibility.
             
                 <a href="/images/dashboard_ping_pub_3_5_4.png" target="_blank"><img src="/images/dashboard_keplr_step_3_5_5_private_key.png" style="width:450px; height:auto;"></a>
                     
@@ -236,15 +224,13 @@ There are several ways to do this:
 
     === "I have an external wallet"
 
+        Step-by-step instructions are provided below for **Keplr** and **Cosmostation**. The same process — install the wallet or extension, log in, enable the Gonka chain, and copy your address — also works in [Fox Wallet](https://foxwallet.com/){target=_blank}.
+
         === "Keplr mobile app"
 
             ??? note "Important note on wallet-bridge compatibility. Please read carefully  if you intend to sell Gonka coins via the Ethereum bridge"
-                The bridge currently expects a specific account setup. Some wallets may let you create a Gonka account and even export a private key, but that does not always mean the account will work correctly with the bridge. For bridge use, please create your Gonka account in one of the following ways:
+                If your wallet was created using a **mnemonic (seed) phrase**, the account is compatible with the Ethereum bridge but requires extra steps — the bridge will deliver tokens to a different `gonka1…` address than the one your wallet shows. You still control those funds and can access them by deriving the correct key. See [Addresses and keys](../cross-chain-transfers/ethereum-bridge/addresses-and-keys.md) for details. For the simplest bridge experience, create your Gonka account via the `inferenced` CLI or Keplr “Connect with Google” flow.
 
-                - With the `inferenced` CLI tool
-                - In Keplr using the “Connect with Google” flow
-                
-                These are the recommended and supported options for users who need Ethereum bridge compatibility.
 
             Open Keplr mobile app and log in to your wallet. Select the menu in the top left corner.
             
@@ -271,14 +257,10 @@ There are several ways to do this:
         === "Keplr browser extension"
 
             ??? note "Important note on wallet-bridge compatibility. Please read carefully  if you intend to sell Gonka coins via the Ethereum bridge"
-                The bridge currently expects a specific account setup. Some wallets may let you create a Gonka account and even export a private key, but that does not always mean the account will work correctly with the bridge. For bridge use, please create your Gonka account in one of the following ways:
+                If your wallet was created using a **mnemonic (seed) phrase**, the account is compatible with the Ethereum bridge but requires extra steps — the bridge will deliver tokens to a different `gonka1…` address than the one your wallet shows. You still control those funds and can access them by deriving the correct key. See [Addresses and keys](../cross-chain-transfers/ethereum-bridge/addresses-and-keys.md) for details. For the simplest bridge experience, create your Gonka account via the `inferenced` CLI or Keplr “Connect with Google” flow.
 
-                - With the `inferenced` CLI tool
-                - In Keplr using the “Connect with Google” flow
-                
-                These are the recommended and supported options for users who need Ethereum bridge compatibility.
 
-            Install an extension for your browser (if you have extension installed, go to the step [“Add Gonka network to your wallet”](#add-gonka-network-to-your-wallet).
+            Install an extension for your browser (if you have the extension installed, go to the step [“Add Gonka network to your wallet”](#add-gonka-network-to-your-wallet)).
             
             Go to [the official Keplr website](https://www.keplr.app/){target=_blank} and click "Get Keplr wallet".
             
@@ -330,6 +312,55 @@ There are several ways to do this:
 
             You copied your Gonka account address. You can share it with anyone who will send you payments. Sharing it is safe. 
             To access your wallet on a mobile device, download the Keplr app and log in using the same method you used during registration. Your Gonka Network account will automatically appear in the mobile wallet app.
+
+        === "Cosmostation browser extension"
+
+            !!! note "Important Notice: Extra steps required for bridge use"
+                This option uses an account created from a mnemonic phrase. Because Ethereum and Gonka use different BIP-44 derivation paths, the bridge will deliver tokens to a different `gonka1…` address than the one your wallet shows. You still control that address (you can derive the Ethereum key from the same mnemonic using coin type `60`), but it requires a manual key derivation step. For a simpler bridge experience, create your Gonka account via the `inferenced` CLI tool or via Keplr ("Connect with Google" path) instead.
+
+            Install the [Cosmostation Wallet browser extension](https://cosmostation.io/products/application) if you haven't already (if you have the extension installed, go to the step ["Add Gonka network to your Cosmostation wallet"](#add-gonka-network-to-your-cosmostation-wallet)).
+            
+            <a href="/images/1_cosmostation.png" target="_blank"><img src="/images/1_cosmostation.png" style="width:500px; height:auto;"></a>
+                    
+            Add the extension to your browser.
+            
+            <a href="/images/2_cosmostation_add_extention.png" target="_blank"><img src="/images/2_cosmostation_add_extention.png" style="width:500px; height:auto;"></a>
+
+            Open the Cosmostation extension and log in to your existing wallet.
+
+            #### Add Gonka network to your Cosmostation wallet
+
+            In the top-right corner, click "All Networks" and select the Gonka chain to add it to your wallet.
+            
+            <a href="/images/10_cosmostation_select_gonka_network.png" target="_blank"><img src="/images/10_cosmostation_select_gonka_network.png" style="width:auto; height:337.5px;"></a>
+            
+            Your Gonka account is now active. To copy your address, click the address above your balance. It usually starts with `gonka...`.
+                
+            <a href="/images/11_cosmostation_gonka_created.png" target="_blank"><img src="/images/11_cosmostation_gonka_created.png" style="width:auto; height:337.5px;"></a>
+
+            You copied your Gonka account address. You can share it with anyone who will send you payments. Sharing it is safe.
+
+            #### View your Gonka private key
+
+            Click on the Wallet name at the top. Click "Manage" on the top-right corner, then click the Wallet name. 
+                    
+            <a href="/images/12_cosmostation_click_name.png" target="_blank"><img src="/images/12_cosmostation_click_name.png" style="width:auto; height:337.5px;"></a>
+            
+            Click "View private key".
+            
+            <a href="/images/13_cosmostation_view_private_key.png" target="_blank"><img src="/images/13_cosmostation_view_private_key.png" style="width:auto; height:337.5px;"></a>
+            
+            Verify your password.
+            
+            <a href="/images/14_cosmostation_verify_password.png" target="_blank"><img src="/images/14_cosmostation_verify_password.png" style="width:auto; height:337.5px;"></a>
+            
+            Choose "Gonka" from the list.
+            
+            <a href="/images/15_cosmostation.png" target="_blank"><img src="/images/15_cosmostation.png" style="width:auto; height:337.5px;"></a>
+               
+            Click on "Gonka" to see the private key. Copy your private key or recovery phrase and store it securely (a hard copy is preferred).
+            
+            <a href="/images/16_cosmostation_copy_private_key.png" target="_blank"><img src="/images/16_cosmostation_copy_private_key.png" style="width:auto; height:337.5px;"></a>
 
 === "Via `inferenced` CLI tool"
     

--- a/docs/zh/wallet/create-account.md
+++ b/docs/zh/wallet/create-account.md
@@ -3,16 +3,16 @@
 要开始使用 Gonka 网络，你首先需要创建一个 Gonka 账户。
 有几种方法可以做到这一点：
 
-- 通过外部钱包（Keplr）
+- 通过外部钱包（Keplr、Cosmostation、Fox Wallet）
 - 通过 `inferenced` CLI 工具
 
-!!! note "关于钱包与桥接兼容性的重要说明。如果你打算通过以太坊桥出售 Gonka 代币，请仔细阅读"
-    桥接目前要求特定的账户设置方式。某些钱包可能允许你创建 Gonka 账户甚至导出私钥，但这并不意味着该账户可以与桥接正常配合使用。如需使用桥接功能，请通过以下方式创建你的 Gonka 账户：
+!!! note "桥接兼容性与助记词（seed phrase）"
+    如果你使用**助记词（seed phrase）**创建 Gonka 账户——如 Cosmostation 和 Fox Wallet 默认采用的方式——该账户**与以太坊桥接兼容**，但桥接会将代币发送到与你钱包显示的不同的 `gonka1…` 地址。这是因为以太坊和 Gonka 使用不同的 BIP-44 派生路径（币种类型 `60` vs `118`），同一助记词在两条链上会产生不同的私钥。你仍然控制这些资金，可以通过额外的密钥派生步骤来访问它们。详见 [地址和密钥](../cross-chain-transfers/ethereum-bridge/addresses-and-keys.md)。
+
+    如需最简便的桥接体验——让钱包自动显示桥接使用的地址，无需额外派生步骤——请通过以下方式创建你的 Gonka 账户：
 
     - 使用 `inferenced` CLI 工具
     - 在 Keplr 中使用"Connect with Google"流程
-    
-    这些是需要以太坊桥接兼容性的用户的推荐和支持选项。
 
 === "外部钱包"
 
@@ -35,12 +35,8 @@
             点击 "Connect with Google"，按照提示通过 Gmail 登录。
 
             ??? note "关于钱包与桥接兼容性的重要说明。如果你打算通过以太坊桥出售 Gonka 代币，请仔细阅读"
-                桥接目前要求特定的账户设置方式。某些钱包可能允许你创建 Gonka 账户甚至导出私钥，但这并不意味着该账户可以与桥接正常配合使用。如需使用桥接功能，请通过以下方式创建你的 Gonka 账户：
+                如果你的钱包是使用**助记词（seed phrase）**创建的，该账户与以太坊桥接兼容，但需要额外步骤——桥接会将代币发送到与你钱包显示的不同的 `gonka1…` 地址。你仍然控制这些资金，可以通过派生正确的密钥来访问。详见 [地址和密钥](../cross-chain-transfers/ethereum-bridge/addresses-and-keys.md)。如需最简便的桥接体验，请通过 `inferenced` CLI 或 Keplr "Connect with Google" 流程创建你的 Gonka 账户。
 
-                - 使用 `inferenced` CLI 工具
-                - 在 Keplr 中使用"Connect with Google"流程
-                
-                这些是需要以太坊桥接兼容性的用户的推荐和支持选项。
                 
             <a href="/images/keplr_mobile_recovery_phrase.PNG" target="_blank"><img src="/images/keplr_mobile_recovery_phrase.PNG" style="width:auto; height:337.5px;"></a>
                 
@@ -99,12 +95,8 @@
             点击 "Connect with Google"，按照提示通过 Gmail 登录。
 
             ??? note "关于钱包与桥接兼容性的重要说明。如果你打算通过以太坊桥出售 Gonka 代币，请仔细阅读"
-                桥接目前要求特定的账户设置方式。某些钱包可能允许你创建 Gonka 账户甚至导出私钥，但这并不意味着该账户可以与桥接正常配合使用。如需使用桥接功能，请通过以下方式创建你的 Gonka 账户：
+                如果你的钱包是使用**助记词（seed phrase）**创建的，该账户与以太坊桥接兼容，但需要额外步骤——桥接会将代币发送到与你钱包显示的不同的 `gonka1…` 地址。你仍然控制这些资金，可以通过派生正确的密钥来访问。详见 [地址和密钥](../cross-chain-transfers/ethereum-bridge/addresses-and-keys.md)。如需最简便的桥接体验，请通过 `inferenced` CLI 或 Keplr "Connect with Google" 流程创建你的 Gonka 账户。
 
-                - 使用 `inferenced` CLI 工具
-                - 在 Keplr 中使用"Connect with Google"流程
-                
-                这些是需要以太坊桥接兼容性的用户的推荐和支持选项。
                 
             <a href="/images/keplr_welcome_to_keplr.png" target="_blank"><img src="/images/keplr_welcome_to_keplr.png" style="width:500px; height:auto;"></a>
                 
@@ -156,7 +148,7 @@
                 粘贴你的私钥。
 
                 ??? note "关于钱包与桥接兼容性的重要说明。如果你打算通过以太坊桥出售 Gonka 代币，请仔细阅读"
-                    桥接目前要求特定的账户设置方式。某些钱包可能允许你创建 Gonka 账户甚至导出私钥，但这并不意味着该账户可以与桥接正常配合使用。如需使用桥接功能，请通过以下方式创建你的 Gonka 账户：
+                    如果你的钱包是使用**助记词（seed phrase）**创建的，该账户与以太坊桥接兼容，但需要额外步骤——桥接会将代币发送到与你钱包显示的不同的 `gonka1…` 地址。你仍然控制这些资金，可以通过派生正确的密钥来访问。详见 [地址和密钥](../cross-chain-transfers/ethereum-bridge/addresses-and-keys.md)。如需最简便的桥接体验，请通过 `inferenced` CLI 或 Keplr "Connect with Google" 流程创建你的 Gonka 账户。
 
                     - 使用 `inferenced` CLI 工具
                     - 在 Keplr 中使用"Connect with Google"流程
@@ -236,15 +228,13 @@
 
     === "我已有外部钱包"
 
+        以下提供了 **Keplr** 和 **Cosmostation** 的分步说明。同样的流程——安装钱包或扩展、登录、启用 Gonka 链、复制地址——也适用于 [Fox Wallet](https://foxwallet.com/){target=_blank}。
+
         === "Keplr 移动应用"
 
             ??? note "关于钱包与桥接兼容性的重要说明。如果你打算通过以太坊桥出售 Gonka 代币，请仔细阅读"
-                桥接目前要求特定的账户设置方式。某些钱包可能允许你创建 Gonka 账户甚至导出私钥，但这并不意味着该账户可以与桥接正常配合使用。如需使用桥接功能，请通过以下方式创建你的 Gonka 账户：
+                如果你的钱包是使用**助记词（seed phrase）**创建的，该账户与以太坊桥接兼容，但需要额外步骤——桥接会将代币发送到与你钱包显示的不同的 `gonka1…` 地址。你仍然控制这些资金，可以通过派生正确的密钥来访问。详见 [地址和密钥](../cross-chain-transfers/ethereum-bridge/addresses-and-keys.md)。如需最简便的桥接体验，请通过 `inferenced` CLI 或 Keplr "Connect with Google" 流程创建你的 Gonka 账户。
 
-                - 使用 `inferenced` CLI 工具
-                - 在 Keplr 中使用"Connect with Google"流程
-                
-                这些是需要以太坊桥接兼容性的用户的推荐和支持选项。
 
             打开 Keplr 移动应用并登录你的钱包。点击左上角的菜单。
             
@@ -271,12 +261,8 @@
         === "Keplr 浏览器扩展"
 
             ??? note "关于钱包与桥接兼容性的重要说明。如果你打算通过以太坊桥出售 Gonka 代币，请仔细阅读"
-                桥接目前要求特定的账户设置方式。某些钱包可能允许你创建 Gonka 账户甚至导出私钥，但这并不意味着该账户可以与桥接正常配合使用。如需使用桥接功能，请通过以下方式创建你的 Gonka 账户：
+                如果你的钱包是使用**助记词（seed phrase）**创建的，该账户与以太坊桥接兼容，但需要额外步骤——桥接会将代币发送到与你钱包显示的不同的 `gonka1…` 地址。你仍然控制这些资金，可以通过派生正确的密钥来访问。详见 [地址和密钥](../cross-chain-transfers/ethereum-bridge/addresses-and-keys.md)。如需最简便的桥接体验，请通过 `inferenced` CLI 或 Keplr "Connect with Google" 流程创建你的 Gonka 账户。
 
-                - 使用 `inferenced` CLI 工具
-                - 在 Keplr 中使用"Connect with Google"流程
-                
-                这些是需要以太坊桥接兼容性的用户的推荐和支持选项。
 
             如果你尚未安装浏览器扩展，请先进行安装（如果已安装扩展，可直接跳转至步骤 ["将 Gonka 网络添加到你的钱包"](#add-gonka-network-to-your-wallet)）。
             
@@ -330,6 +316,55 @@
 
             你已复制 Gonka 账户地址。你可以将其分享给任何需要向你转账的人，分享地址是安全的。
             如果你需要在移动设备上访问钱包，请下载 Keplr 应用，并使用注册时相同的方式登录。你的 Gonka Network 账户将自动显示在移动端钱包中。
+
+        === "Cosmostation 浏览器扩展"
+
+            !!! note "重要提示：使用桥接需要额外步骤"
+                此选项使用由助记词创建的账户。由于以太坊和 Gonka 使用不同的 BIP-44 派生路径，桥接会将代币发送到与你钱包显示的不同的 `gonka1…` 地址。你仍然控制该地址（可以使用相同助记词通过币种类型 `60` 派生以太坊密钥），但需要手动派生密钥。为获得更简便的桥接体验，请改为通过 `inferenced` CLI 工具或 Keplr（"Connect with Google"流程）创建你的 Gonka 账户。
+
+            如果尚未安装，请先安装 [Cosmostation Wallet 浏览器扩展](https://cosmostation.io/products/application)（如果已安装扩展，可直接跳转至步骤 ["将 Gonka 网络添加到你的 Cosmostation 钱包"](#将-gonka-网络添加到你的-cosmostation-钱包)）。
+            
+            <a href="/images/1_cosmostation.png" target="_blank"><img src="/images/1_cosmostation.png" style="width:500px; height:auto;"></a>
+                    
+            将扩展添加到你的浏览器。
+            
+            <a href="/images/2_cosmostation_add_extention.png" target="_blank"><img src="/images/2_cosmostation_add_extention.png" style="width:500px; height:auto;"></a>
+
+            打开 Cosmostation 扩展并登录你的现有钱包。
+
+            #### 将 Gonka 网络添加到你的 Cosmostation 钱包
+
+            在右上角点击 "All Networks"，然后选择 Gonka 链将其添加到你的钱包中。
+            
+            <a href="/images/10_cosmostation_select_gonka_network.png" target="_blank"><img src="/images/10_cosmostation_select_gonka_network.png" style="width:auto; height:337.5px;"></a>
+            
+            你的 Gonka 账户现已激活。要复制你的地址，请点击余额上方的地址。地址通常以 `gonka...` 开头。
+                
+            <a href="/images/11_cosmostation_gonka_created.png" target="_blank"><img src="/images/11_cosmostation_gonka_created.png" style="width:auto; height:337.5px;"></a>
+
+            你已复制 Gonka 账户地址。你可以将其分享给任何需要向你转账的人，分享地址是安全的。
+
+            #### 查看你的 Gonka 私钥
+
+            点击顶部的钱包名称。点击右上角的 "Manage"，然后点击钱包名称。
+                    
+            <a href="/images/12_cosmostation_click_name.png" target="_blank"><img src="/images/12_cosmostation_click_name.png" style="width:auto; height:337.5px;"></a>
+            
+            点击 "View private key"（查看私钥）。
+            
+            <a href="/images/13_cosmostation_view_private_key.png" target="_blank"><img src="/images/13_cosmostation_view_private_key.png" style="width:auto; height:337.5px;"></a>
+            
+            验证你的密码。
+            
+            <a href="/images/14_cosmostation_verify_password.png" target="_blank"><img src="/images/14_cosmostation_verify_password.png" style="width:auto; height:337.5px;"></a>
+            
+            从列表中选择 "Gonka"。
+            
+            <a href="/images/15_cosmostation.png" target="_blank"><img src="/images/15_cosmostation.png" style="width:auto; height:337.5px;"></a>
+               
+            点击 "Gonka" 查看私钥。复制你的私钥或恢复短语并安全存储（建议使用纸质备份）。
+            
+            <a href="/images/16_cosmostation_copy_private_key.png" target="_blank"><img src="/images/16_cosmostation_copy_private_key.png" style="width:auto; height:337.5px;"></a>
 
 === "通过 `inferenced` CLI 工具"
     


### PR DESCRIPTION
## Summary
- Add **Cosmostation browser extension** tab under "I have an external wallet" with full step-by-step instructions including private key export, shortcut link to skip installation, and bridge compatibility note (EN + ZH)
- Add **Fox Wallet** as intro text in "I have an external wallet" section — visible before any wallet tab, explaining the same flow applies
- **Rewrite all bridge compatibility notes** (top-level + 5 internal Keplr notes) to accurately state that mnemonic-based accounts **are compatible** with the bridge but require extra key derivation steps. Previously said "will not work correctly with the bridge"
- Add link to [Addresses and keys](https://gonka.ai/docs/cross-chain-transfers/ethereum-bridge/addresses-and-keys/) page in all bridge notes
- Fix missing closing parenthesis in Keplr "I have" shortcut link

## Test plan
- [ ] Verify "I have an external wallet" shows Fox Wallet intro text before the wallet tabs
- [ ] Verify Cosmostation tab renders with all screenshots and private key export steps
- [ ] Verify shortcut link in Cosmostation tab jumps to "Add Gonka network" section
- [ ] Verify all bridge notes use the new "compatible but requires extra steps" wording
- [ ] Verify links to Addresses and keys page work correctly
- [ ] Check ZH version matches EN structure


Made with [Cursor](https://cursor.com)