### PR TITLE
docs(wallet): move Fox Wallet note to page level, above tabs

### DIFF
--- a/docs/wallet/create-account.md
+++ b/docs/wallet/create-account.md
@@ -14,6 +14,8 @@ There are several ways to do this:
     - With the `inferenced` CLI tool
     - In Keplr using the “Connect with Google” flow
 
+Step-by-step instructions are provided below for **Keplr** and **Cosmostation**. The same process — install the wallet or extension, log in, enable the Gonka chain, and copy your address — also works in [Fox Wallet](https://foxwallet.com/){target=_blank}.
+
 === "External wallet"
 
     === "I do not have an external wallet"
@@ -223,8 +225,6 @@ There are several ways to do this:
             <a href="/images/16_cosmostation_copy_private_key.png" target="_blank"><img src="/images/16_cosmostation_copy_private_key.png" style="width:auto; height:337.5px;"></a>
 
     === "I have an external wallet"
-
-        Step-by-step instructions are provided below for **Keplr** and **Cosmostation**. The same process — install the wallet or extension, log in, enable the Gonka chain, and copy your address — also works in [Fox Wallet](https://foxwallet.com/){target=_blank}.
 
         === "Keplr mobile app"
 

--- a/docs/zh/wallet/create-account.md
+++ b/docs/zh/wallet/create-account.md
@@ -14,6 +14,8 @@
     - 使用 `inferenced` CLI 工具
     - 在 Keplr 中使用"Connect with Google"流程
 
+以下提供了 **Keplr** 和 **Cosmostation** 的分步说明。同样的流程——安装钱包或扩展、登录、启用 Gonka 链、复制地址——也适用于 [Fox Wallet](https://foxwallet.com/){target=_blank}。
+
 === "外部钱包"
 
     === "我没有外部钱包"
@@ -227,8 +229,6 @@
             <a href="/images/16_cosmostation_copy_private_key.png" target="_blank"><img src="/images/16_cosmostation_copy_private_key.png" style="width:auto; height:337.5px;"></a>
 
     === "我已有外部钱包"
-
-        以下提供了 **Keplr** 和 **Cosmostation** 的分步说明。同样的流程——安装钱包或扩展、登录、启用 Gonka 链、复制地址——也适用于 [Fox Wallet](https://foxwallet.com/){target=_blank}。
 
         === "Keplr 移动应用"
 


### PR DESCRIPTION
## Summary
- Move the Fox Wallet intro text from inside the "I have an external wallet" tab to **page level**, right after the "Bridge compatibility and seed (mnemonic) phrases" note
- Now visible to all users regardless of which tab they are viewing
- Updated both EN and ZH versions

## Test plan
- [ ] Verify Fox Wallet text appears between the bridge note and the tab bar
- [ ] Verify it is no longer inside "I have an external wallet" tab


Made with [Cursor](https://cursor.com)