### PR TITLE
docs(wallet): make section headings consistent across wallet tabs

### DIFF
--- a/docs/wallet/create-account.md
+++ b/docs/wallet/create-account.md
@@ -260,7 +260,7 @@ Step-by-step instructions are provided below for **Keplr** and **Cosmostation**.
                 If your wallet was created using a **mnemonic (seed) phrase**, the account is compatible with the Ethereum bridge but requires extra steps — the bridge will deliver tokens to a different `gonka1…` address than the one your wallet shows. You still control those funds and can access them by deriving the correct key. See [Addresses and keys](../cross-chain-transfers/ethereum-bridge/addresses-and-keys.md) for details. For the simplest bridge experience, create your Gonka account via the `inferenced` CLI or Keplr “Connect with Google” flow.
 
 
-            Install an extension for your browser (if you have the extension installed, go to the step [“Add Gonka network to your wallet”](#add-gonka-network-to-your-wallet)).
+            Install an extension for your browser (if you have the extension installed, go to the step [“Add Gonka network to your Keplr wallet”](#add-gonka-network-to-your-keplr-wallet)).
             
             Go to [the official Keplr website](https://www.keplr.app/){target=_blank} and click "Get Keplr wallet".
             
@@ -287,7 +287,7 @@ Step-by-step instructions are provided below for **Keplr** and **Cosmostation**.
             At this point, the extension is installed, but not yet connected to your wallet. 
             Next, open the extension and log in to your wallet. Once you are logged in, follow the steps below to  and continue with the setup process.
 
-            #### Add Gonka network to your wallet
+            #### Add Gonka network to your Keplr wallet
 
             Here is the guide on how to add the Gonka network to your wallet and how your Gonka account will be created.
             Open Keplr browser extension. Navigate to the menu on the top left corner”.

--- a/docs/zh/wallet/create-account.md
+++ b/docs/zh/wallet/create-account.md
@@ -264,7 +264,7 @@
                 如果你的钱包是使用**助记词（seed phrase）**创建的，该账户与以太坊桥接兼容，但需要额外步骤——桥接会将代币发送到与你钱包显示的不同的 `gonka1…` 地址。你仍然控制这些资金，可以通过派生正确的密钥来访问。详见 [地址和密钥](../cross-chain-transfers/ethereum-bridge/addresses-and-keys.md)。如需最简便的桥接体验，请通过 `inferenced` CLI 或 Keplr "Connect with Google" 流程创建你的 Gonka 账户。
 
 
-            如果你尚未安装浏览器扩展，请先进行安装（如果已安装扩展，可直接跳转至步骤 ["将 Gonka 网络添加到你的钱包"](#add-gonka-network-to-your-wallet)）。
+            如果你尚未安装浏览器扩展，请先进行安装（如果已安装扩展，可直接跳转至步骤 ["将 Gonka 网络添加到你的 Keplr 钱包"](#将-gonka-网络添加到你的-keplr-钱包)）。
             
             前往 [the official Keplr website](https://www.keplr.app/){target=_blank} 点击 "Get Keplr wallet"（获取 Keplr 钱包）。
             
@@ -291,7 +291,7 @@
             此时扩展已安装完成，但尚未连接到你的钱包。
             接下来请打开扩展并登录你的钱包。登录后，按照以下步骤继续完成设置。
 
-            #### 将 Gonka 网络添加到你的钱包
+            #### 将 Gonka 网络添加到你的 Keplr 钱包
 
             以下是如何将 Gonka 网络添加到钱包，以及如何创建你的 Gonka 账户的指南。
             打开 Keplr 浏览器扩展，进入左上角菜单。


### PR DESCRIPTION
## Summary
- Rename `#### Add Gonka network to your wallet` (Keplr) to `#### Add Gonka network to your Keplr wallet` so both wallet tabs follow the same `Add Gonka network to your [Wallet] wallet` pattern
- Update the Keplr shortcut anchor link to match the new heading
- Updated both EN and ZH versions

## Test plan
- [ ] Verify Keplr shortcut link "Add Gonka network to your Keplr wallet" scrolls to the correct section
- [ ] Verify Cosmostation shortcut link still works


Made with [Cursor](https://cursor.com)