### PR TITLE
docs(wallet): unify bridge notes, fix anchor links and headings

### DIFF
--- a/docs/wallet/create-account.md
+++ b/docs/wallet/create-account.md
@@ -36,8 +36,8 @@ Step-by-step instructions are provided below for **Keplr** and **Cosmostation**.
 
             Click "Connect with Google". Follow the instructions to sign in via Gmail.
 
-            ??? note "Important note on wallet-bridge compatibility. Please read carefully  if you intend to sell Gonka coins via the Ethereum bridge"
-                If your wallet was created using a **mnemonic (seed) phrase**, the account is compatible with the Ethereum bridge but requires extra steps — the bridge will deliver tokens to a different `gonka1…` address than the one your wallet shows. You still control those funds and can access them by deriving the correct key. See [Addresses and keys](../cross-chain-transfers/ethereum-bridge/addresses-and-keys.md) for details. For the simplest bridge experience, create your Gonka account via the `inferenced` CLI or Keplr “Connect with Google” flow.
+            !!! note "Bridge compatibility"
+                Accounts created with the Keplr “Connect with Google” flow are key-based rather than seed-phrase based, so they are fully compatible with the Ethereum bridge — the bridge delivers tokens to the same `gonka1…` address your wallet shows, with no extra derivation step. See [Addresses and keys](../cross-chain-transfers/ethereum-bridge/addresses-and-keys.md) for details.
 
                 
             <a href="/images/keplr_mobile_recovery_phrase.PNG" target="_blank"><img src="/images/keplr_mobile_recovery_phrase.PNG" style="width:auto; height:337.5px;"></a>
@@ -96,8 +96,8 @@ Step-by-step instructions are provided below for **Keplr** and **Cosmostation**.
             
             Click "Connect with Google". Follow the instructions to sign in via Gmail.
 
-            ??? note "Important note on wallet-bridge compatibility. Please read carefully  if you intend to sell Gonka coins via the Ethereum bridge"
-                If your wallet was created using a **mnemonic (seed) phrase**, the account is compatible with the Ethereum bridge but requires extra steps — the bridge will deliver tokens to a different `gonka1…` address than the one your wallet shows. You still control those funds and can access them by deriving the correct key. See [Addresses and keys](../cross-chain-transfers/ethereum-bridge/addresses-and-keys.md) for details. For the simplest bridge experience, create your Gonka account via the `inferenced` CLI or Keplr “Connect with Google” flow.
+            !!! note "Bridge compatibility"
+                Accounts created with the Keplr “Connect with Google” flow are key-based rather than seed-phrase based, so they are fully compatible with the Ethereum bridge — the bridge delivers tokens to the same `gonka1…` address your wallet shows, with no extra derivation step. See [Addresses and keys](../cross-chain-transfers/ethereum-bridge/addresses-and-keys.md) for details.
 
                 
             <a href="/images/keplr_welcome_to_keplr.png" target="_blank"><img src="/images/keplr_welcome_to_keplr.png" style="width:500px; height:auto;"></a>
@@ -149,8 +149,8 @@ Step-by-step instructions are provided below for **Keplr** and **Cosmostation**.
             
                 Paste your private key.
 
-                ??? note "Important note on wallet-bridge compatibility. Please read carefully  if you intend to sell Gonka coins via the Ethereum bridge"
-                    If your wallet was created using a **mnemonic (seed) phrase**, the account is compatible with the Ethereum bridge but requires extra steps — the bridge will deliver tokens to a different `gonka1…` address than the one your wallet shows. You still control those funds and can access them by deriving the correct key. See [Addresses and keys](../cross-chain-transfers/ethereum-bridge/addresses-and-keys.md) for details. For the simplest bridge experience, create your Gonka account via the `inferenced` CLI or Keplr “Connect with Google” flow.
+                !!! note "Bridge compatibility"
+                    If your Keplr wallet was created from a **mnemonic (seed) phrase**, the account is still compatible with the Ethereum bridge, but the bridge will deliver tokens to a different `gonka1…` address than the one your wallet shows. This happens because Ethereum and Gonka use different BIP-44 derivation paths (coin type `60` vs `118`). You still control those funds and can access them with an extra derivation step. For the simplest bridge experience, create your Gonka account with the `inferenced` CLI tool or the Keplr “Connect with Google” flow. See [Addresses and keys](../cross-chain-transfers/ethereum-bridge/addresses-and-keys.md) for details.
 
             
                 <a href="/images/dashboard_ping_pub_3_5_4.png" target="_blank"><img src="/images/dashboard_keplr_step_3_5_5_private_key.png" style="width:450px; height:auto;"></a>
@@ -169,8 +169,8 @@ Step-by-step instructions are provided below for **Keplr** and **Cosmostation**.
 
         === "Cosmostation browser extension"
 
-            !!! note "Important Notice: Extra steps required for bridge use"
-                This option creates an account using a mnemonic phrase. Because Ethereum and Gonka use different BIP-44 derivation paths, the bridge will deliver tokens to a different `gonka1…` address than the one your wallet shows. You still control that address (you can derive the Ethereum key from the same mnemonic using coin type `60`), but it requires a manual key derivation step. For a simpler bridge experience, create your Gonka account via the `inferenced` CLI tool or via Keplr ("Connect with Google" path) instead.
+            !!! note "Bridge compatibility"
+                This option creates your account from a **mnemonic (seed) phrase**, so the account is compatible with the Ethereum bridge, but the bridge will deliver tokens to a different `gonka1…` address than the one your wallet shows. This happens because Ethereum and Gonka use different BIP-44 derivation paths (coin type `60` vs `118`). You still control that address and can access it with an extra derivation step. For the simplest bridge experience, create your Gonka account with the `inferenced` CLI tool or the Keplr “Connect with Google” flow instead. See [Addresses and keys](../cross-chain-transfers/ethereum-bridge/addresses-and-keys.md) for details.
                 
             Get [Cosmostation Wallet browser extension](https://cosmostation.io/products/application). 
             
@@ -228,8 +228,8 @@ Step-by-step instructions are provided below for **Keplr** and **Cosmostation**.
 
         === "Keplr mobile app"
 
-            ??? note "Important note on wallet-bridge compatibility. Please read carefully  if you intend to sell Gonka coins via the Ethereum bridge"
-                If your wallet was created using a **mnemonic (seed) phrase**, the account is compatible with the Ethereum bridge but requires extra steps — the bridge will deliver tokens to a different `gonka1…` address than the one your wallet shows. You still control those funds and can access them by deriving the correct key. See [Addresses and keys](../cross-chain-transfers/ethereum-bridge/addresses-and-keys.md) for details. For the simplest bridge experience, create your Gonka account via the `inferenced` CLI or Keplr “Connect with Google” flow.
+            !!! note "Bridge compatibility"
+                If your Keplr wallet was created from a **mnemonic (seed) phrase**, the account is still compatible with the Ethereum bridge, but the bridge will deliver tokens to a different `gonka1…` address than the one your wallet shows. This happens because Ethereum and Gonka use different BIP-44 derivation paths (coin type `60` vs `118`). You still control those funds and can access them with an extra derivation step. For the simplest bridge experience, create your Gonka account with the `inferenced` CLI tool or the Keplr “Connect with Google” flow. See [Addresses and keys](../cross-chain-transfers/ethereum-bridge/addresses-and-keys.md) for details.
 
 
             Open Keplr mobile app and log in to your wallet. Select the menu in the top left corner.
@@ -256,11 +256,11 @@ Step-by-step instructions are provided below for **Keplr** and **Cosmostation**.
 
         === "Keplr browser extension"
 
-            ??? note "Important note on wallet-bridge compatibility. Please read carefully  if you intend to sell Gonka coins via the Ethereum bridge"
-                If your wallet was created using a **mnemonic (seed) phrase**, the account is compatible with the Ethereum bridge but requires extra steps — the bridge will deliver tokens to a different `gonka1…` address than the one your wallet shows. You still control those funds and can access them by deriving the correct key. See [Addresses and keys](../cross-chain-transfers/ethereum-bridge/addresses-and-keys.md) for details. For the simplest bridge experience, create your Gonka account via the `inferenced` CLI or Keplr “Connect with Google” flow.
+            !!! note "Bridge compatibility"
+                If your Keplr wallet was created from a **mnemonic (seed) phrase**, the account is still compatible with the Ethereum bridge, but the bridge will deliver tokens to a different `gonka1…` address than the one your wallet shows. This happens because Ethereum and Gonka use different BIP-44 derivation paths (coin type `60` vs `118`). You still control those funds and can access them with an extra derivation step. For the simplest bridge experience, create your Gonka account with the `inferenced` CLI tool or the Keplr “Connect with Google” flow. See [Addresses and keys](../cross-chain-transfers/ethereum-bridge/addresses-and-keys.md) for details.
 
 
-            Install an extension for your browser (if you have the extension installed, go to the step [“Add Gonka network to your wallet”](#add-gonka-network-to-your-wallet)).
+            Install an extension for your browser (if you have the extension installed, go to the step [“Add Gonka network to your Keplr wallet”](#add-gonka-network-to-your-keplr-wallet)).
             
             Go to [the official Keplr website](https://www.keplr.app/){target=_blank} and click "Get Keplr wallet".
             
@@ -285,9 +285,9 @@ Step-by-step instructions are provided below for **Keplr** and **Cosmostation**.
             <a href="/images/keplr_extension.png" target="_blank"><img src="/images/keplr_extension.png" style="width:500px; height:auto;"></a>
 
             At this point, the extension is installed, but not yet connected to your wallet. 
-            Next, open the extension and log in to your wallet. Once you are logged in, follow the steps below to  and continue with the setup process.
+            Next, open the extension and log in to your wallet. Once you are logged in, follow the steps below to continue with the setup process.
 
-            #### Add Gonka network to your wallet
+            #### Add Gonka network to your Keplr wallet
 
             Here is the guide on how to add the Gonka network to your wallet and how your Gonka account will be created.
             Open Keplr browser extension. Navigate to the menu on the top left corner”.
@@ -315,8 +315,8 @@ Step-by-step instructions are provided below for **Keplr** and **Cosmostation**.
 
         === "Cosmostation browser extension"
 
-            !!! note "Important Notice: Extra steps required for bridge use"
-                This option uses an account created from a mnemonic phrase. Because Ethereum and Gonka use different BIP-44 derivation paths, the bridge will deliver tokens to a different `gonka1…` address than the one your wallet shows. You still control that address (you can derive the Ethereum key from the same mnemonic using coin type `60`), but it requires a manual key derivation step. For a simpler bridge experience, create your Gonka account via the `inferenced` CLI tool or via Keplr ("Connect with Google" path) instead.
+            !!! note "Bridge compatibility"
+                This option creates your account from a **mnemonic (seed) phrase**, so the account is compatible with the Ethereum bridge, but the bridge will deliver tokens to a different `gonka1…` address than the one your wallet shows. This happens because Ethereum and Gonka use different BIP-44 derivation paths (coin type `60` vs `118`). You still control that address and can access it with an extra derivation step. For the simplest bridge experience, create your Gonka account with the `inferenced` CLI tool or the Keplr “Connect with Google” flow instead. See [Addresses and keys](../cross-chain-transfers/ethereum-bridge/addresses-and-keys.md) for details.
 
             Install the [Cosmostation Wallet browser extension](https://cosmostation.io/products/application) if you haven't already (if you have the extension installed, go to the step ["Add Gonka network to your Cosmostation wallet"](#add-gonka-network-to-your-cosmostation-wallet)).
             

--- a/docs/zh/wallet/create-account.md
+++ b/docs/zh/wallet/create-account.md
@@ -36,8 +36,8 @@
 
             点击 "Connect with Google"，按照提示通过 Gmail 登录。
 
-            ??? note "关于钱包与桥接兼容性的重要说明。如果你打算通过以太坊桥出售 Gonka 代币，请仔细阅读"
-                如果你的钱包是使用**助记词（seed phrase）**创建的，该账户与以太坊桥接兼容，但需要额外步骤——桥接会将代币发送到与你钱包显示的不同的 `gonka1…` 地址。你仍然控制这些资金，可以通过派生正确的密钥来访问。详见 [地址和密钥](../cross-chain-transfers/ethereum-bridge/addresses-and-keys.md)。如需最简便的桥接体验，请通过 `inferenced` CLI 或 Keplr "Connect with Google" 流程创建你的 Gonka 账户。
+            !!! note "桥接兼容性"
+                通过 Keplr "Connect with Google" 流程创建的账户基于密钥而非助记词，因此与以太坊桥接完全兼容——桥接会将代币发送到与钱包显示相同的 `gonka1…` 地址，无需额外的派生步骤。详见 [地址和密钥](../cross-chain-transfers/ethereum-bridge/addresses-and-keys.md)。
 
                 
             <a href="/images/keplr_mobile_recovery_phrase.PNG" target="_blank"><img src="/images/keplr_mobile_recovery_phrase.PNG" style="width:auto; height:337.5px;"></a>
@@ -96,8 +96,8 @@
             
             点击 "Connect with Google"，按照提示通过 Gmail 登录。
 
-            ??? note "关于钱包与桥接兼容性的重要说明。如果你打算通过以太坊桥出售 Gonka 代币，请仔细阅读"
-                如果你的钱包是使用**助记词（seed phrase）**创建的，该账户与以太坊桥接兼容，但需要额外步骤——桥接会将代币发送到与你钱包显示的不同的 `gonka1…` 地址。你仍然控制这些资金，可以通过派生正确的密钥来访问。详见 [地址和密钥](../cross-chain-transfers/ethereum-bridge/addresses-and-keys.md)。如需最简便的桥接体验，请通过 `inferenced` CLI 或 Keplr "Connect with Google" 流程创建你的 Gonka 账户。
+            !!! note "桥接兼容性"
+                通过 Keplr "Connect with Google" 流程创建的账户基于密钥而非助记词，因此与以太坊桥接完全兼容——桥接会将代币发送到与钱包显示相同的 `gonka1…` 地址，无需额外的派生步骤。详见 [地址和密钥](../cross-chain-transfers/ethereum-bridge/addresses-and-keys.md)。
 
                 
             <a href="/images/keplr_welcome_to_keplr.png" target="_blank"><img src="/images/keplr_welcome_to_keplr.png" style="width:500px; height:auto;"></a>
@@ -149,13 +149,8 @@
             
                 粘贴你的私钥。
 
-                ??? note "关于钱包与桥接兼容性的重要说明。如果你打算通过以太坊桥出售 Gonka 代币，请仔细阅读"
-                    如果你的钱包是使用**助记词（seed phrase）**创建的，该账户与以太坊桥接兼容，但需要额外步骤——桥接会将代币发送到与你钱包显示的不同的 `gonka1…` 地址。你仍然控制这些资金，可以通过派生正确的密钥来访问。详见 [地址和密钥](../cross-chain-transfers/ethereum-bridge/addresses-and-keys.md)。如需最简便的桥接体验，请通过 `inferenced` CLI 或 Keplr "Connect with Google" 流程创建你的 Gonka 账户。
-
-                    - 使用 `inferenced` CLI 工具
-                    - 在 Keplr 中使用"Connect with Google"流程
-                    
-                    这些是需要以太坊桥接兼容性的用户的推荐和支持选项。
+                !!! note "桥接兼容性"
+                    如果你的 Keplr 钱包是使用**助记词（seed phrase）**创建的，该账户仍与以太坊桥接兼容，但桥接会将代币发送到与你钱包显示的不同的 `gonka1…` 地址。这是因为以太坊和 Gonka 使用不同的 BIP-44 派生路径（币种类型 `60` vs `118`）。你仍然控制这些资金，可以通过额外的派生步骤来访问。如需最简便的桥接体验，请通过 `inferenced` CLI 工具或 Keplr "Connect with Google" 流程创建你的 Gonka 账户。详见 [地址和密钥](../cross-chain-transfers/ethereum-bridge/addresses-and-keys.md)。
             
                 <a href="/images/dashboard_ping_pub_3_5_4.png" target="_blank"><img src="/images/dashboard_keplr_step_3_5_5_private_key.png" style="width:450px; height:auto;"></a>
                     
@@ -173,8 +168,8 @@
 
         === "Cosmostation 浏览器扩展"
 
-            !!! note "重要提示：使用桥接需要额外步骤"
-                此选项通过助记词创建账户。由于以太坊和 Gonka 使用不同的 BIP-44 派生路径，桥接会将代币发送到与你钱包显示的不同的 `gonka1…` 地址。你仍然控制该地址（可以使用相同助记词通过币种类型 `60` 派生以太坊密钥），但需要手动派生密钥。为获得更简便的桥接体验，请改为通过 `inferenced` CLI 工具或 Keplr（"Connect with Google"流程）创建你的 Gonka 账户。
+            !!! note "桥接兼容性"
+                此选项通过**助记词（seed phrase）**创建账户，因此该账户与以太坊桥接兼容，但桥接会将代币发送到与你钱包显示的不同的 `gonka1…` 地址。这是因为以太坊和 Gonka 使用不同的 BIP-44 派生路径（币种类型 `60` vs `118`）。你仍然控制该地址，可以通过额外的派生步骤来访问。如需最简便的桥接体验，请改为通过 `inferenced` CLI 工具或 Keplr "Connect with Google" 流程创建你的 Gonka 账户。详见 [地址和密钥](../cross-chain-transfers/ethereum-bridge/addresses-and-keys.md)。
                 
             获取 [Cosmostation Wallet 浏览器扩展](https://cosmostation.io/products/application)。
             
@@ -232,8 +227,8 @@
 
         === "Keplr 移动应用"
 
-            ??? note "关于钱包与桥接兼容性的重要说明。如果你打算通过以太坊桥出售 Gonka 代币，请仔细阅读"
-                如果你的钱包是使用**助记词（seed phrase）**创建的，该账户与以太坊桥接兼容，但需要额外步骤——桥接会将代币发送到与你钱包显示的不同的 `gonka1…` 地址。你仍然控制这些资金，可以通过派生正确的密钥来访问。详见 [地址和密钥](../cross-chain-transfers/ethereum-bridge/addresses-and-keys.md)。如需最简便的桥接体验，请通过 `inferenced` CLI 或 Keplr "Connect with Google" 流程创建你的 Gonka 账户。
+            !!! note "桥接兼容性"
+                如果你的 Keplr 钱包是使用**助记词（seed phrase）**创建的，该账户仍与以太坊桥接兼容，但桥接会将代币发送到与你钱包显示的不同的 `gonka1…` 地址。这是因为以太坊和 Gonka 使用不同的 BIP-44 派生路径（币种类型 `60` vs `118`）。你仍然控制这些资金，可以通过额外的派生步骤来访问。如需最简便的桥接体验，请通过 `inferenced` CLI 工具或 Keplr "Connect with Google" 流程创建你的 Gonka 账户。详见 [地址和密钥](../cross-chain-transfers/ethereum-bridge/addresses-and-keys.md)。
 
 
             打开 Keplr 移动应用并登录你的钱包。点击左上角的菜单。
@@ -260,11 +255,11 @@
 
         === "Keplr 浏览器扩展"
 
-            ??? note "关于钱包与桥接兼容性的重要说明。如果你打算通过以太坊桥出售 Gonka 代币，请仔细阅读"
-                如果你的钱包是使用**助记词（seed phrase）**创建的，该账户与以太坊桥接兼容，但需要额外步骤——桥接会将代币发送到与你钱包显示的不同的 `gonka1…` 地址。你仍然控制这些资金，可以通过派生正确的密钥来访问。详见 [地址和密钥](../cross-chain-transfers/ethereum-bridge/addresses-and-keys.md)。如需最简便的桥接体验，请通过 `inferenced` CLI 或 Keplr "Connect with Google" 流程创建你的 Gonka 账户。
+            !!! note "桥接兼容性"
+                如果你的 Keplr 钱包是使用**助记词（seed phrase）**创建的，该账户仍与以太坊桥接兼容，但桥接会将代币发送到与你钱包显示的不同的 `gonka1…` 地址。这是因为以太坊和 Gonka 使用不同的 BIP-44 派生路径（币种类型 `60` vs `118`）。你仍然控制这些资金，可以通过额外的派生步骤来访问。如需最简便的桥接体验，请通过 `inferenced` CLI 工具或 Keplr "Connect with Google" 流程创建你的 Gonka 账户。详见 [地址和密钥](../cross-chain-transfers/ethereum-bridge/addresses-and-keys.md)。
 
 
-            如果你尚未安装浏览器扩展，请先进行安装（如果已安装扩展，可直接跳转至步骤 ["将 Gonka 网络添加到你的钱包"](#add-gonka-network-to-your-wallet)）。
+            如果你尚未安装浏览器扩展，请先进行安装（如果已安装扩展，可直接跳转至步骤 ["将 Gonka 网络添加到你的 Keplr 钱包"](#将-gonka-网络添加到你的-keplr-钱包)）。
             
             前往 [the official Keplr website](https://www.keplr.app/){target=_blank} 点击 "Get Keplr wallet"（获取 Keplr 钱包）。
             
@@ -291,7 +286,7 @@
             此时扩展已安装完成，但尚未连接到你的钱包。
             接下来请打开扩展并登录你的钱包。登录后，按照以下步骤继续完成设置。
 
-            #### 将 Gonka 网络添加到你的钱包
+            #### 将 Gonka 网络添加到你的 Keplr 钱包
 
             以下是如何将 Gonka 网络添加到钱包，以及如何创建你的 Gonka 账户的指南。
             打开 Keplr 浏览器扩展，进入左上角菜单。
@@ -319,8 +314,8 @@
 
         === "Cosmostation 浏览器扩展"
 
-            !!! note "重要提示：使用桥接需要额外步骤"
-                此选项使用由助记词创建的账户。由于以太坊和 Gonka 使用不同的 BIP-44 派生路径，桥接会将代币发送到与你钱包显示的不同的 `gonka1…` 地址。你仍然控制该地址（可以使用相同助记词通过币种类型 `60` 派生以太坊密钥），但需要手动派生密钥。为获得更简便的桥接体验，请改为通过 `inferenced` CLI 工具或 Keplr（"Connect with Google"流程）创建你的 Gonka 账户。
+            !!! note "桥接兼容性"
+                此选项通过**助记词（seed phrase）**创建账户，因此该账户与以太坊桥接兼容，但桥接会将代币发送到与你钱包显示的不同的 `gonka1…` 地址。这是因为以太坊和 Gonka 使用不同的 BIP-44 派生路径（币种类型 `60` vs `118`）。你仍然控制该地址，可以通过额外的派生步骤来访问。如需最简便的桥接体验，请改为通过 `inferenced` CLI 工具或 Keplr "Connect with Google" 流程创建你的 Gonka 账户。详见 [地址和密钥](../cross-chain-transfers/ethereum-bridge/addresses-and-keys.md)。
 
             如果尚未安装，请先安装 [Cosmostation Wallet 浏览器扩展](https://cosmostation.io/products/application)（如果已安装扩展，可直接跳转至步骤 ["将 Gonka 网络添加到你的 Cosmostation 钱包"](#将-gonka-网络添加到你的-cosmostation-钱包)）。
             


### PR DESCRIPTION
## Summary

Audit and cleanup of the **Create a Gonka account** page (`wallet/create-account.md`) and its Chinese counterpart, covering three things requested in review:

- **Consistent bridge notes.** All bridge-compatibility callouts are now a single `!!! note "Bridge compatibility"` admonition with unified wording (same BIP-44 `60` vs `118` explanation, same recommendation, same link to *Addresses and keys*). Placement is now logical per flow:
  - **Positive** note in the Keplr "Connect with Google" flow (key-based, fully bridge-compatible) — the old note there wrongly warned about mnemonics, which this flow doesn't use.
  - **Conditional** note in Keplr flows where the creation method is unknown ("I have a wallet", import).
  - **Definite** note for Cosmostation (always mnemonic-based).
- **Correct "Add Gonka network to your wallet" links.** Headings are now parallel — `Add Gonka network to your Keplr wallet` / `...Cosmostation wallet` — with anchors that match their in-text links. In the ZH page this also **fixes a broken link** that pointed to the English slug `#add-gonka-network-to-your-wallet`.
- **Consistent heading formatting** across both pipelines.

Also fixed a small typo (EN: "follow the steps below to  and continue") and removed an inconsistent extra bullet list inside the ZH import note.

## Files
- `docs/wallet/create-account.md`
- `docs/zh/wallet/create-account.md`

## Test plan
- [ ] Build the site and confirm both pages render without strict-mode errors
- [ ] Verify the "Add Gonka network to your Keplr/Cosmostation wallet" anchor links jump to the correct headings (EN + ZH)
- [ ] Visually confirm bridge notes look consistent across the Keplr/Cosmostation tabs

Made with [Cursor](https://cursor.com)