### PR TITLE
docs(faq): update "Can I buy GNK" with WGNK on Uniswap

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -26,13 +26,15 @@ GNK is the native coin of the Gonka network. It is used to incentivize participa
 
 ### Can I buy GNK coin?
 
-No, you can not buy GNK on exchanges right now because the coin has not been listed yet.
-Follow official announcements on [Twitter](https://x.com/gonka_ai) for any updates regarding listings.
+Native GNK is **not listed on any centralized exchange (CEX)** yet, so you cannot buy it on a CEX. Follow official announcements on [Twitter](https://x.com/gonka_ai) for any updates regarding listings.
 
-At the moment, the main legitimate way to obtain GNK before any listing is to [mine as a Host](https://gonka.ai/host/quickstart/) (GNK can already be earned by contributing computational resources to the network).
+There are, however, two legitimate ways to obtain GNK today:
 
-!!! note "Important"
-	Be aware that fake GNK listings and pages currently exist, including on CoinGecko. These pages do not represent the official GNK coin and are not affiliated with the project in any way. GNK is not tradable on any exchange at this time. Any coin claiming to be GNK, whether on Solana or other networks, is not an official GNK asset. Always verify information through official channels.
+- **Mine as a Host.** Contribute computational resources to the network and earn GNK directly. See [mine as a Host](https://gonka.ai/host/quickstart/).
+- **Buy WGNK on Ethereum and bridge it back to GNK.** GNK can be bridged to Ethereum as **WGNK** (wrapped GNK), which is a standard ERC-20 that trades on DEXs such as Uniswap. You can buy WGNK there and then [bridge it back to native GNK](cross-chain-transfers/ethereum-bridge/withdraw-gnk.md). See the [Ethereum bridge overview](cross-chain-transfers/ethereum-bridge/overview.md).
+
+!!! note "Important — verify the contract address"
+	The **only** official Ethereum representation of GNK is **WGNK** at `0x972a7a92d92796a98801a8818bcf91f1648f2f68` — this address is both the bridge contract and the WGNK ERC-20 token. Always verify this exact address before trading, e.g. on [Uniswap](https://app.uniswap.org/explore/tokens/ethereum/0x972a7a92d92796a98801a8818bcf91f1648f2f68) or [CoinMarketCap](https://coinmarketcap.com/currencies/gonka/). Fake GNK listings and pages still exist on other trackers and networks: any coin claiming to be GNK on Solana, or on any contract other than the WGNK address above, is **not** an official GNK asset. Always verify information through official channels.
 
 ### What makes the protocol efficient?
 What differentiates Gonka from the "big players" is its pricing and the fact that, despite the Host's size, the inference is distributed equally. To learn more, please review the [Whitepaper](https://gonka.ai/whitepaper.pdf).

--- a/docs/zh/FAQ.md
+++ b/docs/zh/FAQ.md
@@ -26,13 +26,15 @@ GNK 是 Gonka 网络的原生代币。它用于激励参与者、为资源定价
 
 ### 我可以购买 GNK 代币吗？
 
-不可以，您目前无法在交易所购买 GNK，因为该代币尚未上市。
-请关注 [Twitter](https://x.com/gonka_ai) 上的官方公告，了解有关上市的任何更新。
+原生 GNK **尚未在任何中心化交易所（CEX）上市**，因此您无法在 CEX 上购买它。请关注 [Twitter](https://x.com/gonka_ai) 上的官方公告，了解有关上市的任何更新。
 
-目前，在任何上线交易之前，获取 GNK 的主要合法方式是 [作为 Host 进行挖矿](https://gonka.ai/host/quickstart/) (通过向网络贡献计算资源，已经可以赚取GNK。).
+不过，目前有两种合法的方式来获取 GNK：
 
-!!! note "重要"
-	请注意，目前存在虚假的 GNK 上线信息和页面，包括在 CoinGecko 和 CoinMarketCap 上。 这些页面并不代表官方的 GNK 代币，也与项目方没有任何关联。 目前 GNK 尚未在任何交易所上线或可交易。 任何声称是 GNK 的代币，无论是在 Solana 还是其他网络上，都不是官方的 GNK 资产。请务必通过官方渠道核实所有相关信息。
+- **作为 Host 进行挖矿。** 通过向网络贡献计算资源直接赚取 GNK。请参阅 [作为 Host 进行挖矿](https://gonka.ai/host/quickstart/)。
+- **在以太坊上购买 WGNK，然后将其桥接回 GNK。** GNK 可以作为 **WGNK**（wrapped GNK）桥接到以太坊，WGNK 是一种标准的 ERC-20 代币，可在 Uniswap 等 DEX 上交易。您可以在那里购买 WGNK，然后[将其桥接回原生 GNK](cross-chain-transfers/ethereum-bridge/withdraw-gnk.md)。请参阅 [以太坊桥接概览](cross-chain-transfers/ethereum-bridge/overview.md)。
+
+!!! note "重要 — 请核实合约地址"
+	GNK 在以太坊上**唯一**的官方表示形式是地址为 `0x972a7a92d92796a98801a8818bcf91f1648f2f68` 的 **WGNK** —— 该地址既是桥接合约，也是 WGNK ERC-20 代币。交易前请务必核实此确切地址，例如在 [Uniswap](https://app.uniswap.org/explore/tokens/ethereum/0x972a7a92d92796a98801a8818bcf91f1648f2f68) 或 [CoinMarketCap](https://coinmarketcap.com/currencies/gonka/) 上。请注意，其他追踪网站和网络上仍存在虚假的 GNK 上线信息和页面：任何声称是 GNK 的代币，无论是在 Solana 上，还是在上述 WGNK 地址以外的任何合约上，都不是官方的 GNK 资产。请务必通过官方渠道核实所有相关信息。
 
 ### 协议为何高效？
 Gonka 与那些“头部玩家”之间的区别在于其定价方式，以及即使 Host 的规模不同，推理任务仍然会被公平地分配。若想了解更多内容，请查看[白皮书](https://gonka.ai/whitepaper.pdf).


### PR DESCRIPTION
## Summary

Updates the **"Can I buy GNK coin?"** FAQ entry (EN + ZH) to match reality now that WGNK has on-chain liquidity.

- Native GNK is still **not listed on any CEX** — kept that, but reframed it as "not on a centralized exchange" rather than "can't buy anywhere".
- Added a second legitimate way to obtain GNK: **buy WGNK on a DEX (Uniswap) and bridge it back to native GNK**. WGNK is the bridge contract itself at `0x972a7a92d92796a98801a8818bcf91f1648f2f68`, consistent with the [Ethereum bridge overview](../docs/cross-chain-transfers/ethereum-bridge/overview.md).
- Fixed the now-inaccurate warning that labeled **CoinMarketCap** as a fake listing — the [CMC page](https://coinmarketcap.com/currencies/gonka/) tracks the real WGNK contract. Reworked the note to emphasize verifying the exact contract address and to flag copies on Solana / other contracts as fakes.

References:
- Uniswap WGNK: https://app.uniswap.org/explore/tokens/ethereum/0x972a7a92d92796a98801a8818bcf91f1648f2f68
- CoinMarketCap: https://coinmarketcap.com/currencies/gonka/

## Test plan

- [ ] Review wording for accuracy/policy (esp. whether to mention DEX trading in official FAQ)
- [ ] Confirm relative links to `cross-chain-transfers/ethereum-bridge/{overview,withdraw-gnk}.md` resolve in the built docs
- [ ] Verify EN and ZH copies stay in sync

Made with [Cursor](https://cursor.com)