### PR TITLE
docs(quickstart): emphasize first request runs on Gonka

### DIFF
--- a/docs/developer/quickstart.md
+++ b/docs/developer/quickstart.md
@@ -100,9 +100,9 @@ The exact menu names below may differ between app versions — look for the equi
 
     Use the standard **OpenAI** module, then look for advanced settings to override the **Base Path / Base URL** with your broker's URL.
 
-Prefer to write code instead? Continue to [§1.4 Send your first request](#14-send-your-first-request).
+Prefer to write code instead? Continue to [§1.4 Send your first request on Gonka](#14-send-your-first-request-on-gonka).
 
-### 1.4 Send your first request
+### 1.4 Send your first request on Gonka
 
 Set environment variables:
 

--- a/docs/zh/developer/quickstart.md
+++ b/docs/zh/developer/quickstart.md
@@ -57,7 +57,7 @@ name: index.md
 2. 在经纪商的控制台中生成 API key。
 3. 记下经纪商的 `base_url`（例如 `https://api.<broker-domain>/v1`）以及它支持的模型列表。
 
-### 1.3 发送你的第一个请求
+### 1.3 在 Gonka 上发送你的第一个请求
 
 设置环境变量：
 


### PR DESCRIPTION
## Summary
- Rename the developer quickstart section **§1.4 Send your first request** → **Send your first request on Gonka** (heading + in-page cross-reference + anchor).
- Apply the same emphasis to the Chinese version: **§1.3 发送你的第一个请求** → **在 Gonka 上发送你的第一个请求**.

This makes clear that inference actually runs on the Gonka network, even though the API is served by a community broker.

## Test plan
- [ ] Verify the in-page link in the EN quickstart still scrolls to the renamed section (anchor updated to `#14-send-your-first-request-on-gonka`).
- [ ] Confirm both pages render correctly in the docs build.

Made with [Cursor](https://cursor.com)