### PR TITLE
docs(quickstart): add gonka-api.org demo and sync zh broker links

### DIFF
--- a/docs/developer/quickstart.md
+++ b/docs/developer/quickstart.md
@@ -39,7 +39,7 @@ A broker is an independent operator who runs a Gonka gateway and resells inferen
 - [https://gonkagate.com/](https://gonkagate.com/)
 - [https://gate.joingonka.ai/](https://gate.joingonka.ai/)
 - [https://router.gonkascan.com/](https://router.gonkascan.com/) · [▶ demo](https://youtu.be/1uWmLGPoBCM)
-- [https://gonka-api.org/](https://gonka-api.org/)
+- [https://gonka-api.org/](https://gonka-api.org/) · [▶ demo](https://youtu.be/JgY2ikjcP9M)
 - [https://gonkabroker.com/](https://gonkabroker.com/)
 - [https://router.mingles.ai/](https://router.mingles.ai/) · [▶ demo](https://youtu.be/gegiRnNMavY)
 - [https://console.hyperfusion.io/](https://console.hyperfusion.io/) 

--- a/docs/zh/developer/quickstart.md
+++ b/docs/zh/developer/quickstart.md
@@ -37,13 +37,13 @@ name: index.md
 
 ### 1.1 选择经纪商
 
-- [https://proxy.gonka.gg/](https://proxy.gonka.gg/)
+- [https://proxy.gonka.gg/](https://proxy.gonka.gg/) · [▶ demo](https://drive.google.com/file/d/1-Zk__4cY_ENi0Q8gw-JHgEBz6XZWXKAj/view?pli=1)
 - [https://gonkagate.com/](https://gonkagate.com/)
 - [https://gate.joingonka.ai/](https://gate.joingonka.ai/)
-- [https://router.gonkascan.com/](https://router.gonkascan.com/)
-- [https://gonka-api.org/](https://gonka-api.org/)
+- [https://router.gonkascan.com/](https://router.gonkascan.com/) · [▶ demo](https://youtu.be/1uWmLGPoBCM)
+- [https://gonka-api.org/](https://gonka-api.org/) · [▶ demo](https://youtu.be/JgY2ikjcP9M)
 - [https://gonkabroker.com/](https://gonkabroker.com/)
-- [https://gonka-gateway.mingles.ai/](https://gonka-gateway.mingles.ai/) · [▶ demo](https://youtu.be/gegiRnNMavY)
+- [https://router.mingles.ai/](https://router.mingles.ai/) · [▶ demo](https://youtu.be/gegiRnNMavY)
 - [https://console.hyperfusion.io/](https://console.hyperfusion.io/)
 
 ??? note "关于此列表"


### PR DESCRIPTION
## Summary
- Add demo screencast link (`https://youtu.be/JgY2ikjcP9M`) for the **gonka-api.org** broker in both the English and Chinese developer quickstart guides.
- Sync the Chinese broker list with the English one: add the missing demo links for `proxy.gonka.gg` and `router.gonkascan.com`.
- Fix the Mingles broker URL in the Chinese version to the correct `https://router.mingles.ai/` (matching English).

## Test plan
- [ ] Verify the broker lists render correctly in both `docs/developer/quickstart.md` and `docs/zh/developer/quickstart.md`.
- [ ] Confirm all demo links open the expected videos.

Made with [Cursor](https://cursor.com)