### PR TITLE
add gonka24 broker to quickstart

### DIFF
--- a/docs/assets/javascripts/links.js
+++ b/docs/assets/javascripts/links.js
@@ -39,7 +39,7 @@ function shuffleChildren(container) {
 //
 // The order is re-randomized on every page load.
 function shuffleBrokerList() {
-  const BROKER_HOST_PATTERN = /(proxy\.gonka\.gg|gonkagate\.com|gate\.joingonka\.ai|router\.gonkascan\.com|gonka-api\.org|gonkabroker\.com|gonka-gateway\.mingles\.ai|console\.hyperfusion\.io)/i;
+  const BROKER_HOST_PATTERN = /(gonka24\.com|proxy\.gonka\.gg|gonkagate\.com|gate\.joingonka\.ai|router\.gonkascan\.com|gonka-api\.org|gonkabroker\.com|gonka-gateway\.mingles\.ai|console\.hyperfusion\.io)/i;
 
   const targets = new Set();
   document.querySelectorAll("a[href]").forEach((a) => {

--- a/docs/developer/quickstart.md
+++ b/docs/developer/quickstart.md
@@ -35,6 +35,7 @@ A broker is an independent operator who runs a Gonka gateway and resells inferen
 
 ### 1.1 Pick a broker
 
+- [https://gonka24.com/](https://gonka24.com/)
 - [https://proxy.gonka.gg/](https://proxy.gonka.gg/) · [▶ demo](https://drive.google.com/file/d/1-Zk__4cY_ENi0Q8gw-JHgEBz6XZWXKAj/view?pli=1)
 - [https://gonkagate.com/](https://gonkagate.com/)
 - [https://gate.joingonka.ai/](https://gate.joingonka.ai/)

--- a/docs/zh/developer/quickstart.md
+++ b/docs/zh/developer/quickstart.md
@@ -37,6 +37,7 @@ name: index.md
 
 ### 1.1 选择经纪商
 
+- [https://gonka24.com/](https://gonka24.com/)
 - [https://proxy.gonka.gg/](https://proxy.gonka.gg/) · [▶ demo](https://drive.google.com/file/d/1-Zk__4cY_ENi0Q8gw-JHgEBz6XZWXKAj/view?pli=1)
 - [https://gonkagate.com/](https://gonkagate.com/)
 - [https://gate.joingonka.ai/](https://gate.joingonka.ai/)


### PR DESCRIPTION
﻿## Summary
- Add gonka24.com to the English Developer Quickstart broker directory.
- Add gonka24.com to the Chinese Developer Quickstart broker directory.
- Include gonka24.com in the broker hostname pattern used by the quickstart list shuffle script.

## Validation
- `git diff --cached --check`
- `node --check docs/assets/javascripts/links.js`
- Confirmed `gonka24.com` appears in both quickstart files and the broker shuffle pattern.

## Notes
- MkDocs build was not run locally because this checkout does not include dependency files and the local Python environment does not have mkdocs installed.