### PR TITLE
docs: add HackerOne embedded vulnerability report page

### DIFF
--- a/docs/report-vulnerability.md
+++ b/docs/report-vulnerability.md
@@ -1,0 +1,7 @@
+# Report a Vulnerability
+
+Found a security issue in Gonka? We appreciate responsible disclosure. Use the form below to submit a vulnerability report directly through HackerOne.
+
+<div id="h1-embedded-submission"></div>
+
+<script async src="https://hackerone.com/529ebea7-e684-4c88-8699-cf287d945866/embedded_submissions/script" data-url="https://hackerone.com/529ebea7-e684-4c88-8699-cf287d945866/embedded_submissions/new?locale=en" data-name="h1-embedded-submission" type="text/javascript"></script>

--- a/docs/zh/report-vulnerability.md
+++ b/docs/zh/report-vulnerability.md
@@ -1,0 +1,7 @@
+# 报告漏洞
+
+在 Gonka 中发现了安全问题？我们鼓励负责任的漏洞披露。请使用下方表单，通过 HackerOne 直接提交漏洞报告。
+
+<div id="h1-embedded-submission"></div>
+
+<script async src="https://hackerone.com/529ebea7-e684-4c88-8699-cf287d945866/embedded_submissions/script" data-url="https://hackerone.com/529ebea7-e684-4c88-8699-cf287d945866/embedded_submissions/new?locale=en" data-name="h1-embedded-submission" type="text/javascript"></script>


### PR DESCRIPTION
## Summary
- Add a standalone page `docs/report-vulnerability.md` that embeds the HackerOne embedded submission form, allowing researchers to report security vulnerabilities directly from the docs site.
- The page is reachable at `/report-vulnerability/` but is intentionally **not** added to the navigation menu for now.

## Notes
- The site already embeds raw HTML/`<script>` in pages (e.g. `signup.md`, `login.md`), and `minify_html: false` keeps the script tag intact, so the embed renders the same way.
- The HackerOne form loads in an iframe restricted to allowlisted domains in the HackerOne program settings. It will not render on `localhost`/`127.0.0.1` unless that origin is added to the allowlist; it should work once `gonka.ai` is allowlisted in HackerOne.
- `mkdocs build` passes with `strict: true`.

## Test plan
- [ ] Deploy to a domain allowlisted in HackerOne and confirm the form renders at `/report-vulnerability/`.

Made with [Cursor](https://cursor.com)