### PR TITLE
docs: reword vulnerability page to network-focused tone

### DIFF
--- a/docs/report-vulnerability.md
+++ b/docs/report-vulnerability.md
@@ -1,6 +1,6 @@
 # Report a Vulnerability
 
-Found a security issue in Gonka? We appreciate responsible disclosure. Use the form below to submit a vulnerability report directly through HackerOne.
+Found a security issue in Gonka? Responsible disclosure helps keep the network secure for everyone. Use the form below to submit a vulnerability report directly through HackerOne.
 
 <div id="h1-embedded-submission"></div>
 

--- a/docs/zh/report-vulnerability.md
+++ b/docs/zh/report-vulnerability.md
@@ -1,6 +1,6 @@
 # 报告漏洞
 
-在 Gonka 中发现了安全问题？我们鼓励负责任的漏洞披露。请使用下方表单，通过 HackerOne 直接提交漏洞报告。
+在 Gonka 中发现了安全问题？负责任的漏洞披露有助于保障整个网络的安全。请使用下方表单，通过 HackerOne 直接提交漏洞报告。
 
 <div id="h1-embedded-submission"></div>
 


### PR DESCRIPTION
## Summary
- Reword the intro on the vulnerability report page to a more decentralized / network-focused tone of voice.
- Old: "Found a security issue in Gonka? We appreciate responsible disclosure. ..."
- New: "Found a security issue in Gonka? Responsible disclosure helps keep the network secure for everyone. ..."
- Applied to both the English (`docs/report-vulnerability.md`) and Chinese (`docs/zh/report-vulnerability.md`) pages.

## Test plan
- [ ] Confirm copy reads well on `/report-vulnerability/` and `/zh/report-vulnerability/`.

Made with [Cursor](https://cursor.com)