### PR TITLE
docs: add Report a Vulnerability page to nav (EN/ZH)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,6 +74,7 @@ nav:
     - Network updates: network-updates.md
     - FAQ: FAQ.md
     - Get help: help.md
+    - Report a Vulnerability: report-vulnerability.md
 
 # Visual
 theme:
@@ -232,6 +233,7 @@ plugins:
             Network updates: 网络更新
             FAQ: 常见问题
             "Get help": 获取支持
+            "Report a Vulnerability": 报告漏洞
 
 strict: true
 


### PR DESCRIPTION
## Summary
- Add the existing **Report a Vulnerability** page to the navigation under the **Resources** section (next to "Get help").
- Add the Chinese nav translation (`报告漏洞`) so the page appears on both the English and 中文 sites.

The content files (`docs/report-vulnerability.md` and `docs/zh/report-vulnerability.md`) already existed but were not linked in the menu.

## Placement rationale
Resources groups support/contact-oriented items (FAQ, Get help), which is the natural home for a security disclosure form, rather than the static Reference section.

## Test plan
- [ ] Build the site and confirm "Report a Vulnerability" appears under Resources (EN)
- [ ] Confirm "报告漏洞" appears under 资源 (ZH)

Made with [Cursor](https://cursor.com)