### PR TITLE
docs(FAQ): make WGNK tracker list parallel

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -36,9 +36,9 @@ There are, however, two legitimate ways to obtain GNK today:
 !!! info "Track WGNK price and market data"
 	You can follow WGNK (wrapped GNK) price, market cap, and trading volume on:
 
-	- **CoinGecko** — [Wrapped Gonka](https://www.coingecko.com/en/coins/wrapped-gonka)
-	- **CoinMarketCap** — [Gonka](https://coinmarketcap.com/currencies/gonka/)
-	- **Uniswap** — [WGNK token](https://app.uniswap.org/explore/tokens/ethereum/0x972a7a92d92796a98801a8818bcf91f1648f2f68)
+	- [CoinGecko](https://www.coingecko.com/en/coins/wrapped-gonka)
+	- [CoinMarketCap](https://coinmarketcap.com/currencies/gonka/)
+	- [Uniswap](https://app.uniswap.org/explore/tokens/ethereum/0x972a7a92d92796a98801a8818bcf91f1648f2f68)
 
 !!! warning "Verify the contract address before trading"
 	The **only** official Ethereum representation of GNK is **WGNK** at `0x972a7a92d92796a98801a8818bcf91f1648f2f68` — this address is both the bridge contract and the WGNK ERC-20 token. Always confirm any listing or trade resolves to this exact address.

--- a/docs/zh/FAQ.md
+++ b/docs/zh/FAQ.md
@@ -36,9 +36,9 @@ GNK是Gonka网络的原生代币。它用于激励参与者、为资源定价，
 !!! info "查询WGNK价格和市场数据"
 	您可以在以下平台查询WGNK（封装版GNK）的价格、市值和交易量：
 
-	- **CoinGecko** —— [Wrapped Gonka](https://www.coingecko.com/en/coins/wrapped-gonka)
-	- **CoinMarketCap** —— [Gonka](https://coinmarketcap.com/currencies/gonka/)
-	- **Uniswap** —— [WGNK代币](https://app.uniswap.org/explore/tokens/ethereum/0x972a7a92d92796a98801a8818bcf91f1648f2f68)
+	- [CoinGecko](https://www.coingecko.com/en/coins/wrapped-gonka)
+	- [CoinMarketCap](https://coinmarketcap.com/currencies/gonka/)
+	- [Uniswap](https://app.uniswap.org/explore/tokens/ethereum/0x972a7a92d92796a98801a8818bcf91f1648f2f68)
 
 !!! warning "交易前请验证合约地址"
 	GNK在以太坊上的**唯一**官方表示是位于`0x972a7a92d92796a98801a8818bcf91f1648f2f68`的**WGNK**——该地址既是桥接合约也是WGNK ERC-20代币。交易前请务必确认任何列表或交易都对应此确切地址。


### PR DESCRIPTION
## Summary
- Fix the unstructured WGNK tracker list in the "Can I buy GNK coin?" FAQ section.
- Previously each item had a different, inconsistent link label ("Wrapped Gonka" / "Gonka" / "WGNK token"). Now each list item uses the platform name itself as the link, so the list is parallel and consistent.
- Applied to EN (`docs/FAQ.md`) and ZH (`docs/zh/FAQ.md`).

## Before
- **CoinGecko** — Wrapped Gonka
- **CoinMarketCap** — Gonka
- **Uniswap** — WGNK token

## After
- CoinGecko
- CoinMarketCap
- Uniswap

## Test plan
- [ ] Build docs and verify the list renders cleanly with working links.

Made with [Cursor](https://cursor.com)