### PR TITLE
docs: announce devshard v3 runtime upgrade passed governance

### DIFF
--- a/docs/network-updates.md
+++ b/docs/network-updates.md
@@ -8,6 +8,33 @@
    
     This page is not guaranteed to be exhaustive. For the latest information, including governance vote launches and their current status, refer to on-chain data or check available explorers and dashboards.
 
+## July 11, 2026
+
+**The v0.2.13-devshard-v3 runtime upgrade proposal has passed governance**
+
+The devshard v3 runtime has been approved on-chain and added to `DevshardEscrowParams.approved_versions`.
+
+This proposal covered [the devshard v3 release.](https://github.com/gonka-ai/gonka/tree/upgrade-v0.2.14/proposals/governance-artifacts/update-v0.2.13-devshard-v3)
+
+This is a devshard-only runtime upgrade. It operates independently of full-chain software upgrades and does not require a chain binary upgrade.
+
+With the proposal approved, v3 now runs in parallel with the existing devshard runtimes. The new process is served under the `/devshard/v3` prefix, while existing devshard traffic can continue on earlier runtime prefixes until brokers switch traffic to v3.
+
+The release publishes the `devshardd` binary as a Gonka release artifact. `versiond` automatically downloads the binary, verifies the sha256 hash, and starts an additional `devshardd` process inside the existing `versiond` container.
+
+No mainnet restart or manual host steps are expected for this type of devshard-only runtime upgrade.
+
+**Action items for Brokers**
+
+Brokers should switch inference traffic to `/devshard/v3` before the mainnet v0.2.14 chain upgrade. This lets them keep serving inference while the chain upgrade runs, without depending on the deprecated classic API path.
+
+**Key Changes**
+
+1) Prepared brokers to keep serving inference during the v0.2.14 chain upgrade without depending on the deprecated classic API path.
+2) Improved RAM utilization.
+3) Fixed gateway runtime behavior.
+4) Enabled safe switching between SQLite and Postgres storage.
+
 ## July 8, 2026
 
 **The v0.2.13-devshard-v3 runtime upgrade proposal has entered governance**

--- a/docs/zh/network-updates.md
+++ b/docs/zh/network-updates.md
@@ -8,6 +8,33 @@
 
     本页面的内容不保证完整。如需获取最新信息，包括治理投票的发布及其当前状态，请参考链上数据或查看可用的浏览器和仪表板。
 
+## 2026年7月11日
+
+**v0.2.13-devshard-v3 运行时升级提案已通过治理**
+
+devshard v3 运行时已通过链上批准并添加至 `DevshardEscrowParams.approved_versions`。
+
+本提案涵盖 [devshard v3 发布。](https://github.com/gonka-ai/gonka/tree/upgrade-v0.2.14/proposals/governance-artifacts/update-v0.2.13-devshard-v3)
+
+这是一个仅针对 devshard 的运行时升级。它独立于完整链软件升级运行，无需链二进制升级。
+
+提案通过后，v3 现在与现有的 devshard 运行时并行运行。新进程在 `/devshard/v3` 前缀下提供服务，而现有的 devshard 流量可以继续使用早期运行时前缀，直到代理将流量切换到 v3。
+
+该发布将 `devshardd` 二进制文件作为 Gonka 发布工件发布。`versiond` 会自动下载二进制文件，验证 sha256 哈希值，并在现有 `versiond` 容器内启动额外的 `devshardd` 进程。
+
+对于此类仅 devshard 的运行时升级，无需重启主网或手动执行主机步骤。
+
+**代理的行动事项**
+
+代理应在主网 v0.2.14 链升级之前将推理流量切换到 `/devshard/v3`。这样他们就能在链升级运行期间继续提供推理服务，而无需依赖已弃用的经典 API 路径。
+
+**关键变更**
+
+1) 使代理能够在 v0.2.14 链升级期间继续提供推理服务，而无需依赖已弃用的经典 API 路径。
+2) 改进了 RAM 利用率。
+3) 修复了网关运行时行为。
+4) 支持在 SQLite 和 Postgres 存储之间安全切换。
+
 ## 2026年7月8日
 
 **v0.2.13-devshard-v3 运行时升级提案已进入治理阶段**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a standard "passed governance" announcement for the `v0.2.13-devshard-v3` runtime upgrade to the Announcements (network updates) page, in both English (`docs/network-updates.md`) and Chinese (`docs/zh/network-updates.md`).

The announcement follows the format of the previous devshard v2 "passed governance" post and the existing v3 "entered governance" vote announcement. It notes that:

- v3 has been approved on-chain and added to `DevshardEscrowParams.approved_versions`.
- v3 now runs in parallel with the existing devshard runtimes, served under the `/devshard/v3` prefix.
- Brokers should switch inference traffic to `/devshard/v3` before the mainnet v0.2.14 chain upgrade.
- No mainnet restart or manual host steps are expected for this devshard-only runtime upgrade.

## Notes

- Dated July 11, 2026 (after the vote deadline noted in the "entered governance" post).