### PR TITLE
docs(host): update multi-model PoC delegation guidance after epoch 328-329 incident

### DIFF
--- a/docs/host/multi_model_poc.md
+++ b/docs/host/multi_model_poc.md
@@ -2,18 +2,40 @@
 
 Multi-model Proof-of-Compute (PoC) arrived in v0.2.12 and expanded again in v0.2.13.
 
+!!! warning "Delegation guidance update (July 2026)"
+
+    After the epoch 328–329 incident, two rules apply when choosing a delegate:
+
+    - **Do not delegate to guardian nodes.** Guardians are the fallback mechanism
+      for PoC validation. Concentrating delegations on them ties the primary
+      voting mechanism and the fallback to the same hardware, so both fail
+      together. Earlier guidance that suggested a guardian node as a delegation
+      target is withdrawn. A protocol-level restriction is planned for v0.2.14.
+    - **Avoid concentrating delegations on any single host.** A delegation only
+      counts if the delegate submits a PoC store commit that epoch. If one heavily
+      delegated host goes down, all weight delegated to it vanishes at once and
+      the model group can lose its validation majority. If you operate several
+      accounts, point them at different delegates. Percentage-based delegation to
+      multiple hosts from one account is not supported yet.
+
 ## What changed in v0.2.12 and v0.2.13
 
 Before v0.2.12, the network operated a single enforced model: `Qwen/Qwen3-235B-A22B-Instruct-2507-FP8`. v0.2.12 added `moonshotai/Kimi-K2.6` as the second governance-approved model and introduced per-model participation, delegation, and penalty timing. v0.2.13 recalibrated model coefficients and added `MiniMaxAI/MiniMax-M2.7` as the third governance-approved model.
 
 As of epoch `308`, `Qwen/Qwen3-235B-A22B-Instruct-2507-FP8` has been retired by governance (proposal 78) and `MiniMaxAI/MiniMax-M2.7` is the base model and active PoC model. `poc_params.models` on mainnet contains:
 
-| `model_id` | Current mainnet status | `weight_scale_factor` | `penalty_start_epoch` |
-|---|---|---:|---:|
-| `MiniMaxAI/MiniMax-M2.7` | Active | `0.3024` | `278` |
-| `moonshotai/Kimi-K2.6` | Re-bootstrapping (restored via follow-up vote) | `0.78` | `251` |
+| `model_id` | Current mainnet status |
+|---|---|
+| `MiniMaxAI/MiniMax-M2.7` | Base model, active |
+| `moonshotai/Kimi-K2.6` | Re-bootstrapping after the epoch 328–329 incident |
 
-These values are governance-controlled and can change. Before acting, always verify them with a live `params` query on the chain you use.
+Per-model `weight_scale_factor` and `penalty_start_epoch` change through governance too often to list here reliably. Always read them from a live `params` query on the chain you use:
+
+```
+./inferenced query inference params --node "$NODE" -o json
+```
+
+Look inside `poc_params` → `models`.
 
 ??? note "Why multi-model PoC works this way"
 
@@ -70,6 +92,8 @@ Do you run the model?
    │     │
    │     │  ├─ YES
    │     │  │  └─ Delegate to that host (share 5% of weight)
+   │     │  │     Never a guardian node; prefer a host that is
+   │     │  │     not already a top delegation target
    │     │
    │     │  └─ NO
    │     │     └─ Refuse delegation (~10% penalty)
@@ -88,7 +112,14 @@ In most cases:
 If you are not running a given model:
 
 - If you operate multiple nodes and at least one runs that model: delegate to your own node for that model
-- If you do not run that model at all: delegate to a host you trust
+- If you do not run that model at all: delegate to a host you trust. When picking one:
+    - it must **not** be a guardian node;
+    - it should have served that model **stably across recent epochs** (a delegation
+      counts only if the delegate submits a PoC store commit that epoch);
+    - it should have had **non-zero consensus weight in the previous epoch**;
+    - prefer hosts that are **not already major delegation targets** — if
+      `max_model_voting_power_percentage` is set, weight delegated above the cap
+      is burned, and concentration makes the whole group fragile.
 - If you do not trust any delegate: use `refuse-poc-delegation` for that model
 
 Once `penalty_start_epoch` is reached for a model, not participating in that model directly or via valid delegation may reduce your consensus weight, depending on governance-configured parameters.
@@ -174,6 +205,15 @@ Whether you **actually ran PoC** for a model is not taken from those stored rows
 - the delegate had **non-zero consensus weight in the previous epoch**.
 
 Otherwise your delegation is ignored for that model for that epoch (same practical outcome as if you had not delegated), and penalty rules may still apply once they are enabled.
+
+!!! warning "If your delegate goes down, you may be penalized"
+
+    If the delegate fails to submit a PoC store commit for that model in the
+    epoch, your delegation is ignored and you are treated as **not participating**
+    for that model — the `no_participation_penalty` may apply to you even though
+    you delegated in good faith. Re-check your delegate's participation regularly
+    (for example, after any network incident) and switch delegates if they became
+    unreliable.
 
 When a delegation **does** count, your **full** weight is counted toward that host's influence on validating that model's PoC. Separately, **`delegation_share`** in `params` can move part of your **original** consensus weight to them when weights are finalized — that is a different knob from the refusal / no-participation percentages; read `params` for the exact values.
 
@@ -331,6 +371,8 @@ If **`refusal_penalty`**, **`no_participation_penalty`**, and **`delegation_shar
 5. Check whether `refusal_penalty`, `no_participation_penalty`, and `delegation_share` are non-zero.
 6. For each model, decide whether you want to run it, delegate, refuse, or do nothing.
 7. If you run the model yourself, make sure your PoC stack submits valid PoC v2 store commits for that model.
-8. If you delegate, verify the result with `poc-delegation`.
+8. If you delegate, verify the result with `poc-delegation`, and confirm the delegate actually committed PoC for that model in the current epoch.
 9. For new models, watch `bootstrap_model_preeligibility` events and send `declare-poc-intent` before the capture height if you plan to participate.
 10. After any config change, restart, or new host onboarding, make sure no unsupported models are present in the persisted DAPI configuration.
+11. Never set a guardian node as your delegation target.
+12. After any network incident, re-verify that your delegate is still serving the model; delegations are snapshotted at validation start and cannot be re-routed mid-epoch.

--- a/docs/network-updates.md
+++ b/docs/network-updates.md
@@ -177,7 +177,9 @@ Delegate your weight to a host that runs Kimi (or send a refusal):
 ```
 ./inferenced tx inference set-poc-delegation moonshotai/Kimi-K2.6 <DELEGATEE>
 ```
-The guardian node `gonka1kx9mca3xm8u8ypzfuhmxey66u0ufxhs7nm6wc5` will run Kimi and can be used as the delegation target.
+~~The guardian node `gonka1kx9mca3xm8u8ypzfuhmxey66u0ufxhs7nm6wc5` will run Kimi and can be used as the delegation target.~~
+
+> **Update (July 15, 2026): this recommendation is withdrawn — do not delegate to guardian nodes.** Guardians are the fallback mechanism for PoC validation and must stay independent from delegations. Pick a non-guardian host that runs the model, and avoid hosts that are already major delegation targets. See the [Multi-Model PoC guide](https://gonka.ai/docs/host/multi_model_poc/) for updated delegation guidance.
 
 **Key timings**
 

--- a/docs/zh/network-updates.md
+++ b/docs/zh/network-updates.md
@@ -177,7 +177,9 @@ docker start api
 ```
 ./inferenced tx inference set-poc-delegation moonshotai/Kimi-K2.6 <DELEGATEE>
 ```
-守护节点 `gonka1kx9mca3xm8u8ypzfuhmxey66u0ufxhs7nm6wc5` 将运行 Kimi，并可作为委托目标。
+~~守护节点 `gonka1kx9mca3xm8u8ypzfuhmxey66u0ufxhs7nm6wc5` 将运行 Kimi，并可作为委托目标。~~
+
+> **更新（2026年7月15日）：该建议已撤回 — 请勿委托给守护节点（guardian）。** 守护节点是 PoC 验证的后备机制，必须与委托保持独立。请选择运行该模型的非守护节点主机，并避免选择已经集中了大量委托的主机。更新后的委托指南请参阅 [Multi-Model PoC 指南](https://gonka.ai/docs/host/multi_model_poc/)。
 
 **关键时间点*** 意向截止时间（第310轮）：区块 **4,797,456** — 大约6月28日，12:00 UTC。
 * 第311轮开始：区块 **4,797,956** — 大约6月28日，12:47 UTC。


### PR DESCRIPTION
## Summary

Updates the Multi-Model PoC host guide and the June 27 network update following the epoch 328–329 Kimi incident, where an MLNode holding a large share of Kimi delegations died on a guardian-operated server and the model group lost its validation majority.

## Changes

### `docs/host/multi_model_poc.md`

- **Withdraw the guardian delegation recommendation.** Adds a prominent warning: do not delegate to guardian nodes — guardians are the fallback mechanism for PoC validation, and concentrating delegations on them ties the primary mechanism and the fallback to the same hardware. A protocol-level restriction is planned for v0.2.14.
- **Warn against delegation concentration.** A delegation only counts if the delegate submits a PoC store commit that epoch; a single heavily delegated host going down can drop the whole group below the validation majority.
- **Delegate-selection checklist** in Recommended actions: not a guardian, stable across recent epochs, non-zero prior-epoch weight, not already a top delegation target (weight above `max_model_voting_power_percentage` is burned).
- **New warning in "Does your delegation actually count?"**: if the delegate goes down, the delegator is treated as not participating and `no_participation_penalty` may apply.
- **Replace stale parameter values.** The per-model `weight_scale_factor` / `penalty_start_epoch` table kept going out of date (e.g. Kimi listed at 0.78 while 0.9 has been in effect since proposal 79); replaced with a live `params` query instruction.
- **Host checklist** extended: verify the delegate actually committed PoC, never target a guardian, re-verify delegates after incidents.

### `docs/network-updates.md` (+ zh translation)

- **Withdraw the June 27 recommendation** to use the guardian node `gonka1kx9...6wc5` as the Kimi delegation target — the node whose failure caused the epoch 328–329 incident. The line is struck through with a dated update note pointing to the revised guidance in the Multi-Model PoC guide.

## Context

Delegation guidance change discussed in the host chats on July 15.