### PR TITLE
docs: announce proposal 86 (+5% weight_scale_factor) and refresh model status tables

### DIFF
--- a/docs/host/multi_model_poc.md
+++ b/docs/host/multi_model_poc.md
@@ -27,7 +27,8 @@ As of epoch `308`, `Qwen/Qwen3-235B-A22B-Instruct-2507-FP8` has been retired by 
 | `model_id` | Current mainnet status |
 |---|---|
 | `MiniMaxAI/MiniMax-M2.7` | Base model, active |
-| `moonshotai/Kimi-K2.6` | Re-bootstrapping after the epoch 328–329 incident |
+| `moonshotai/Kimi-K2.6` | Active (re-bootstrapped at epoch 331 after the epoch 328–329 incident) |
+| `zai-org/GLM-5.2-FP8` | Active (added by proposal 79; non-participation penalty starts at epoch 500) |
 
 Per-model `weight_scale_factor` and `penalty_start_epoch` change through governance too often to list here reliably. Always read them from a live `params` query on the chain you use:
 

--- a/docs/network-updates.md
+++ b/docs/network-updates.md
@@ -212,6 +212,21 @@ export NODE_URL=https://node3.gonka.ai/
 
 More on how the bootstrap works: [https://gonka.ai/docs/host/kimi-bootstrap/](https://gonka.ai/docs/host/kimi-bootstrap/)
 
+## July 16, 2026
+
+**Proposal 86 has passed: weight_scale_factor raised by 5% for Kimi-K2.6 and GLM-5.2**
+
+Governance proposal 86 was approved on-chain (voting ended July 16, 17:53 UTC):
+
+* `moonshotai/Kimi-K2.6`: `weight_scale_factor` increased from `0.90` to `0.945` (+5%).
+* `zai-org/GLM-5.2-FP8`: `weight_scale_factor` increased from `2.47` to `2.5935` (+5%).
+
+All other model and chain parameters remain unchanged. No action is required from hosts. Current values can always be read from a live `params` query (`poc_params` → `models`):
+
+```
+./inferenced query inference params --node "$NODE" -o json
+```
+
 ## July 15, 2026
 
 **Expedited governance vote (proposal 87): remove Kimi-K2.6 for a fast re-bootstrap**

--- a/docs/zh/host/multi_model_poc.md
+++ b/docs/zh/host/multi_model_poc.md
@@ -8,12 +8,19 @@
 
 截至纪元 `308`，`Qwen/Qwen3-235B-A22B-Instruct-2507-FP8` 已由治理（提案 78）退役，`MiniMaxAI/MiniMax-M2.7` 成为基础模型与活跃的 PoC 模型。主网上的 `poc_params.models` 包含以下内容：
 
-| `model_id` | 当前主网状态 | `weight_scale_factor` | `penalty_start_epoch` |
-|---|---|---:|---:|
-| `MiniMaxAI/MiniMax-M2.7` | 活跃 | `0.3024` | `278` |
-| `moonshotai/Kimi-K2.6` | 重新 bootstrap 中（通过后续投票恢复） | `0.78` | `251` |
+| `model_id` | 当前主网状态 |
+|---|---|
+| `MiniMaxAI/MiniMax-M2.7` | 基础模型，活跃 |
+| `moonshotai/Kimi-K2.6` | 活跃（在第 328–329 轮事件后于第 331 轮重新引导） |
+| `zai-org/GLM-5.2-FP8` | 活跃（由提案 79 添加；未参与惩罚自第 500 轮起生效） |
 
-这些值由治理机制控制，可能会发生变化。在执行任何操作前，请务必通过你所使用的链上的实时 `params` 查询来验证这些参数。
+各模型的 `weight_scale_factor` 和 `penalty_start_epoch` 会通过治理频繁变更，无法在此可靠列出。请始终通过你所使用的链上的实时 `params` 查询读取这些参数：
+
+```
+./inferenced query inference params --node "$NODE" -o json
+```
+
+查看 `poc_params` → `models` 中的内容。
 
 ??? note "为何多模型 PoC 采用此设计"
 

--- a/docs/zh/network-updates.md
+++ b/docs/zh/network-updates.md
@@ -212,6 +212,21 @@ export NODE_URL=https://node3.gonka.ai/
 
 有关引导流程的更多信息：[https://gonka.ai/docs/host/kimi-bootstrap/](https://gonka.ai/docs/host/kimi-bootstrap/)
 
+## 2026 年 7 月 16 日
+
+**提案 86 已通过：Kimi-K2.6 与 GLM-5.2 的 weight_scale_factor 提高 5%**
+
+治理提案 86 已链上批准（投票于 7 月 16 日 17:53 UTC 结束）：
+
+* `moonshotai/Kimi-K2.6`：`weight_scale_factor` 从 `0.90` 提高至 `0.945`（+5%）。
+* `zai-org/GLM-5.2-FP8`：`weight_scale_factor` 从 `2.47` 提高至 `2.5935`（+5%）。
+
+其他所有模型和链参数保持不变。主机无需采取任何操作。当前值可随时通过实时 `params` 查询获取（`poc_params` → `models`）：
+
+```
+./inferenced query inference params --node "$NODE" -o json
+```
+
 ## 2026年7月15日
 
 **紧急治理投票（提案87）：移除Kimi-K2.6以快速重新引导**


### PR DESCRIPTION
## Summary
- Add a July 16 entry to `network-updates.md` (EN and ZH) for passed governance proposal 86: `weight_scale_factor` raised for `moonshotai/Kimi-K2.6` (0.90 → 0.945) and `zai-org/GLM-5.2-FP8` (2.47 → 2.5935), +5% each. Values verified against live mainnet params.
- Refresh the model status table in `docs/host/multi_model_poc.md`: Kimi-K2.6 is active again (re-bootstrapped at epoch 331), add the missing GLM-5.2 row.
- Sync the outdated ZH `multi_model_poc.md` with the EN approach: remove the hardcoded per-model factor table (it still showed pre-proposal-79 values) and point readers to a live `params` query instead.

The historical June 26 announcement for proposal 79 (mentioning the old 0.9 / 2.47 values) is intentionally left unchanged.