### PR TITLE
docs(FAQ): correct stale current version 0.2.13 → 0.2.15

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -2190,7 +2190,7 @@ Even when vLLM #33264 merges and the gateway adds a hash → `cache_salt` bridge
 
 ### When will image input be enabled for Kimi on the Gonka gateway?
 
-**Not available today.** ETA — release v0.2.14 or later (current is 0.2.13), no fixed date. Multimodal payloads (`messages[].content` with `type: "image_url"` or `"video_url"`) currently return **HTTP 400** on both public brokers.
+**Not available today.** ETA — release v0.2.14 or later (current is 0.2.15), no fixed date. Multimodal payloads (`messages[].content` with `type: "image_url"` or `"video_url"`) currently return **HTTP 400** on both public brokers.
 
 **Active work, the plan is written and broken into phases.** The planned document `multimodal-inference-plan.md` in `gonka-ai/gonka` (≈466 lines, 6 phases — ML Node, Host↔ML Node, Broker/DAPI, Devshard Protocol, etc.). Until it's published, it's easier to track via the issues / PRs below.
 

--- a/docs/zh/FAQ.md
+++ b/docs/zh/FAQ.md
@@ -2183,7 +2183,7 @@ vLLM 前缀 KV 缓存工作在每个 ML 节点上。网关级 `prompt_cache_key`
 
 ### Kimi 在 Gonka 网关上何时启用图像输入？
 
-**目前不可用。** 预计发布时间为 v0.2.14 或更高版本（当前为 0.2.13），无固定日期。多模态负载（`messages[].content` 包含 `type: "image_url"` 或 `"video_url"`）目前在两个公共经纪人上均返回 **HTTP 400**。
+**目前不可用。** 预计发布时间为 v0.2.14 或更高版本（当前为 0.2.15），无固定日期。多模态负载（`messages[].content` 包含 `type: "image_url"` 或 `"video_url"`）目前在两个公共经纪人上均返回 **HTTP 400**。
 
 **正在进行中，计划已撰写并分为多个阶段。** 计划文档 `multimodal-inference-plan.md` 在 `gonka-ai/gonka` 中（约 466 行，6 个阶段——ML 节点、Host↔ML 节点、经纪人/DAPI、Devshard 协议等）。在发布前，通过下方问题/PR 跟踪更方便。
 


### PR DESCRIPTION
The multimodal-support FAQ answer still stated the current release as `0.2.13`; mainnet is now on `0.2.15`. Bumped the `(current is …)` note in both the English `docs/FAQ.md` and the Chinese mirror `docs/zh/FAQ.md` to keep them consistent.

Scope kept minimal on purpose — other `0.2.13` mentions in the FAQ are contextual (`devshard ≥ 0.2.13` gateway rules, the historical MiniMax v0.2.13 launch) and are correct as written, so they were left untouched.