### PR TITLE
docs: recommend Open Broker as the way to become a broker

### DIFF
--- a/docs/developer/gateway-developer-quickstart.md
+++ b/docs/developer/gateway-developer-quickstart.md
@@ -2,13 +2,13 @@
 
 This guide explains how to run a Gonka devshard gateway on **gonka-mainnet** without installing a full chain node. You will deploy the gateway on your own Linux host, fund a dedicated escrow creator address, open an on-chain devshard escrow, send OpenAI-compatible inference requests, and settle the escrow when you are finished.
 
-If you only need inference through an existing endpoint, start with **[Open Broker](https://openbroker.gonka.gg)** (recommended) or another [community broker](quickstart.md#1-use-a-community-broker-recommended) — that path does not require Docker, on-chain escrows, or an allow-listed creator address. Self-host only when a broker cannot meet your needs; see [Interested in operating a gateway?](quickstart.md#3-interested-in-operating-a-gateway).
+If you want to **become a broker** without running your own allow-listed gateway, use **[Open Broker](https://openbroker.gonka.gg)** — that is the recommended path (see [Developer Quickstart §3](quickstart.md#3-interested-in-operating-a-gateway)). Continue with this guide only when you specifically need a self-hosted on-chain gateway.
 
 ### Allowlisted creator address required
 
 > **Prerequisite:** The `gonka1…` address for your devshard escrow creator (`$DEVSHARD_CREATOR`, from `DEVSHARD_PRIVATE_KEY`) **must** appear on the chain allowlist `devshard_escrow_params.allowed_creator_addresses` **before** you can create an escrow.
 >
-> The allowlist is maintained on-chain through **governance**. You cannot add yourself via `config.devshard.env` or admin settings. Prefer **[Open Broker](https://openbroker.gonka.gg)** or another [community broker](quickstart.md#1-use-a-community-broker-recommended) first. Request allow-list inclusion via GitHub / governance only as a [fallback](quickstart.md#fallback-request-on-chain-allow-list-consideration) when a broker does not fit.
+> The allowlist is maintained on-chain through **governance**. You cannot add yourself via `config.devshard.env` or admin settings. **Do not open a GitHub allow-list issue as the first step** — become a broker via [Open Broker](https://openbroker.gonka.gg) first. Use the [GitHub allow-list fallback](quickstart.md#fallback--github-allow-list-request) only if Open Broker does not fit and you still need your own allow-listed creator address.
 >
 > After you import your key in [§2.3](#23-import-the-creator-key), verify membership in [§2.4](#24-confirm-allowlist-membership). Do not fund the creator or deploy the gateway until that check passes (funding alone does not grant allowlist access).
 
@@ -208,7 +208,7 @@ The name `devshard-create` is only a local label; on-chain transactions use `--f
 
 **Do not skip this step.** Escrow creation in [§4](#4-create-an-escrow-and-open-api-access) only succeeds when `$DEVSHARD_CREATOR` is on the chain allowlist.
 
-You do **not** need to run a validator to use a gateway; you only need your creator address on `devshard_escrow_params.allowed_creator_addresses`. If it is missing, stop here — prefer [Open Broker](https://openbroker.gonka.gg) or another community broker, or follow the [allow-list fallback](quickstart.md#fallback-request-on-chain-allow-list-consideration) only if a broker cannot meet your needs. Re-run this check after any governance vote before creating an escrow.
+You do **not** need to run a validator to use a gateway; you only need your creator address on `devshard_escrow_params.allowed_creator_addresses`. If it is missing, stop here — become a broker via [Open Broker](https://openbroker.gonka.gg), or use the [GitHub allow-list fallback](quickstart.md#fallback--github-allow-list-request) only if Open Broker cannot meet your needs. Re-run this check after any governance vote before creating an escrow.
 
 ```bash
 source config.devshard.env
@@ -670,6 +670,6 @@ Replacing the gateway **image** or recreating the main container would drop in-f
 
 ## Related
 
-- [Developer Quickstart](quickstart.md) — [Open Broker](https://openbroker.gonka.gg) (recommended), other community brokers, and [allow-list fallback](quickstart.md#fallback-request-on-chain-allow-list-consideration)
+- [Developer Quickstart](quickstart.md) — community brokers; [become a broker via Open Broker](quickstart.md#recommended--become-a-broker-with-open-broker); [GitHub allow-list fallback](quickstart.md#fallback--github-allow-list-request)
 
-**Need help?** See the [FAQ](https://gonka.ai/FAQ/), join [Discord](https://discord.com/invite/RADwCT2U6R), or — only if a community broker does not fit — open a [broker / allowlist request](https://github.com/gonka-ai/gonka/issues/new?title=Gateway+allowlist+request) on GitHub.
+**Need help?** See the [FAQ](https://gonka.ai/FAQ/), join [Discord](https://discord.com/invite/RADwCT2U6R), or — only if Open Broker does not fit — open a [gateway allowlist request](https://github.com/gonka-ai/gonka/issues/new?title=Gateway+allowlist+request) on GitHub.

--- a/docs/developer/gateway-developer-quickstart.md
+++ b/docs/developer/gateway-developer-quickstart.md
@@ -2,7 +2,7 @@
 
 This guide explains how to run a Gonka devshard gateway on **gonka-mainnet** without installing a full chain node. You will deploy the gateway on your own Linux host, fund a dedicated escrow creator address, open an on-chain devshard escrow, send OpenAI-compatible inference requests, and settle the escrow when you are finished.
 
-If you want to **become a broker** without running your own allow-listed gateway, use **[Open Broker](https://openbroker.gonka.gg)** — that is the recommended path (see [Developer Quickstart §3](quickstart.md#3-interested-in-operating-a-gateway)). Continue with this guide only when you specifically need a self-hosted on-chain gateway.
+If you want to **become a broker** without running your own allow-listed gateway, use **[Open Broker](https://openbroker.gonka.gg)** - that is the recommended path (see [Developer Quickstart §3](quickstart.md#3-interested-in-operating-a-gateway)). Continue with this guide only when you specifically need a self-hosted on-chain gateway.
 
 ### Allowlisted creator address required
 
@@ -208,7 +208,7 @@ The name `devshard-create` is only a local label; on-chain transactions use `--f
 
 **Do not skip this step.** Escrow creation in [§4](#4-create-an-escrow-and-open-api-access) only succeeds when `$DEVSHARD_CREATOR` is on the chain allowlist.
 
-You do **not** need to run a validator to use a gateway; you only need your creator address on `devshard_escrow_params.allowed_creator_addresses`. If it is missing, stop here — become a broker via [Open Broker](https://openbroker.gonka.gg), or use the [GitHub allow-list fallback](quickstart.md#fallback--github-allow-list-request) only if Open Broker cannot meet your needs. Re-run this check after any governance vote before creating an escrow.
+You do **not** need to run a validator to use a gateway; you only need your creator address on `devshard_escrow_params.allowed_creator_addresses`. If it is missing, stop here - become a broker via [Open Broker](https://openbroker.gonka.gg), or use the [GitHub allow-list fallback](quickstart.md#fallback--github-allow-list-request) only if Open Broker cannot meet your needs. Re-run this check after any governance vote before creating an escrow.
 
 ```bash
 source config.devshard.env
@@ -670,6 +670,6 @@ Replacing the gateway **image** or recreating the main container would drop in-f
 
 ## Related
 
-- [Developer Quickstart](quickstart.md) — community brokers; [become a broker via Open Broker](quickstart.md#recommended--become-a-broker-with-open-broker); [GitHub allow-list fallback](quickstart.md#fallback--github-allow-list-request)
+- [Developer Quickstart](quickstart.md) - community brokers; [become a broker via Open Broker](quickstart.md#recommended--become-a-broker-with-open-broker); [GitHub allow-list fallback](quickstart.md#fallback--github-allow-list-request)
 
-**Need help?** See the [FAQ](https://gonka.ai/FAQ/), join [Discord](https://discord.com/invite/RADwCT2U6R), or — only if Open Broker does not fit — open a [gateway allowlist request](https://github.com/gonka-ai/gonka/issues/new?title=Gateway+allowlist+request) on GitHub.
+**Need help?** See the [FAQ](https://gonka.ai/FAQ/), join [Discord](https://discord.com/invite/RADwCT2U6R), or - only if Open Broker does not fit - open a [gateway allowlist request](https://github.com/gonka-ai/gonka/issues/new?title=Gateway+allowlist+request) on GitHub.

--- a/docs/developer/gateway-developer-quickstart.md
+++ b/docs/developer/gateway-developer-quickstart.md
@@ -2,13 +2,13 @@
 
 This guide explains how to run a Gonka devshard gateway on **gonka-mainnet** without installing a full chain node. You will deploy the gateway on your own Linux host, fund a dedicated escrow creator address, open an on-chain devshard escrow, send OpenAI-compatible inference requests, and settle the escrow when you are finished.
 
-If you only need inference through an existing endpoint, use a [community broker](quickstart.md#1-use-a-community-broker-recommended) instead — that path does not require Docker, on-chain escrows, or an allow-listed creator address.
+If you only need inference through an existing endpoint, start with **[Open Broker](https://openbroker.gonka.gg)** (recommended) or another [community broker](quickstart.md#1-use-a-community-broker-recommended) — that path does not require Docker, on-chain escrows, or an allow-listed creator address. Self-host only when a broker cannot meet your needs; see [Interested in operating a gateway?](quickstart.md#3-interested-in-operating-a-gateway).
 
 ### Allowlisted creator address required
 
 > **Prerequisite:** The `gonka1…` address for your devshard escrow creator (`$DEVSHARD_CREATOR`, from `DEVSHARD_PRIVATE_KEY`) **must** appear on the chain allowlist `devshard_escrow_params.allowed_creator_addresses` **before** you can create an escrow.
 >
-> The allowlist is maintained on-chain through **governance**. You cannot add yourself via `config.devshard.env` or admin settings. Request inclusion through an on-chain governance vote — see [Become a broker](quickstart.md#3-become-a-broker) in the Developer Quickstart — or use a [community broker](quickstart.md#1-use-a-community-broker-recommended) instead.
+> The allowlist is maintained on-chain through **governance**. You cannot add yourself via `config.devshard.env` or admin settings. Prefer **[Open Broker](https://openbroker.gonka.gg)** or another [community broker](quickstart.md#1-use-a-community-broker-recommended) first. Request allow-list inclusion via GitHub / governance only as a [fallback](quickstart.md#fallback-request-on-chain-allow-list-consideration) when a broker does not fit.
 >
 > After you import your key in [§2.3](#23-import-the-creator-key), verify membership in [§2.4](#24-confirm-allowlist-membership). Do not fund the creator or deploy the gateway until that check passes (funding alone does not grant allowlist access).
 
@@ -208,7 +208,7 @@ The name `devshard-create` is only a local label; on-chain transactions use `--f
 
 **Do not skip this step.** Escrow creation in [§4](#4-create-an-escrow-and-open-api-access) only succeeds when `$DEVSHARD_CREATOR` is on the chain allowlist.
 
-You do **not** need to run a validator to use a gateway; you only need your creator address on `devshard_escrow_params.allowed_creator_addresses`. If it is missing, stop here and follow [Become a broker](quickstart.md#3-become-a-broker) to request a governance params update. Re-run this check after any governance vote before creating an escrow.
+You do **not** need to run a validator to use a gateway; you only need your creator address on `devshard_escrow_params.allowed_creator_addresses`. If it is missing, stop here — prefer [Open Broker](https://openbroker.gonka.gg) or another community broker, or follow the [allow-list fallback](quickstart.md#fallback-request-on-chain-allow-list-consideration) only if a broker cannot meet your needs. Re-run this check after any governance vote before creating an escrow.
 
 ```bash
 source config.devshard.env
@@ -670,6 +670,6 @@ Replacing the gateway **image** or recreating the main container would drop in-f
 
 ## Related
 
-- [Developer Quickstart](quickstart.md) — community brokers and [Become a broker](quickstart.md#3-become-a-broker)
+- [Developer Quickstart](quickstart.md) — [Open Broker](https://openbroker.gonka.gg) (recommended), other community brokers, and [allow-list fallback](quickstart.md#fallback-request-on-chain-allow-list-consideration)
 
-**Need help?** See the [FAQ](https://gonka.ai/FAQ/), join [Discord](https://discord.com/invite/RADwCT2U6R), or open a [broker / allowlist request](https://github.com/gonka-ai/gonka/issues/new?title=Request+to+be+added+as+a+Gonka+broker) on GitHub.
+**Need help?** See the [FAQ](https://gonka.ai/FAQ/), join [Discord](https://discord.com/invite/RADwCT2U6R), or — only if a community broker does not fit — open a [broker / allowlist request](https://github.com/gonka-ai/gonka/issues/new?title=Gateway+allowlist+request) on GitHub.

--- a/docs/developer/gateway-developer-quickstart.md
+++ b/docs/developer/gateway-developer-quickstart.md
@@ -8,7 +8,7 @@ If you want to **become a broker** without running your own allow-listed gateway
 
 > **Prerequisite:** The `gonka1…` address for your devshard escrow creator (`$DEVSHARD_CREATOR`, from `DEVSHARD_PRIVATE_KEY`) **must** appear on the chain allowlist `devshard_escrow_params.allowed_creator_addresses` **before** you can create an escrow.
 >
-> The allowlist is maintained on-chain through **governance**. You cannot add yourself via `config.devshard.env` or admin settings. **Do not open a GitHub allow-list issue as the first step** — become a broker via [Open Broker](https://openbroker.gonka.gg) first. Use the [GitHub allow-list fallback](quickstart.md#fallback--github-allow-list-request) only if Open Broker does not fit and you still need your own allow-listed creator address.
+> The allowlist is maintained on-chain through **governance**. You cannot add yourself via `config.devshard.env` or admin settings. Prefer becoming a broker via [Open Broker](https://openbroker.gonka.gg); use a [GitHub allow-list issue as a fallback](quickstart.md#fallback--github-allow-list-request) if Open Broker does not satisfy your needs and you still need your own allow-listed creator address.
 >
 > After you import your key in [§2.3](#23-import-the-creator-key), verify membership in [§2.4](#24-confirm-allowlist-membership). Do not fund the creator or deploy the gateway until that check passes (funding alone does not grant allowlist access).
 

--- a/docs/developer/gateway-developer-quickstart.md
+++ b/docs/developer/gateway-developer-quickstart.md
@@ -8,7 +8,7 @@ If you want to **become a broker** without running your own allow-listed gateway
 
 > **Prerequisite:** The `gonka1…` address for your devshard escrow creator (`$DEVSHARD_CREATOR`, from `DEVSHARD_PRIVATE_KEY`) **must** appear on the chain allowlist `devshard_escrow_params.allowed_creator_addresses` **before** you can create an escrow.
 >
-> The allowlist is maintained on-chain through **governance**. You cannot add yourself via `config.devshard.env` or admin settings. Prefer becoming a broker via [Open Broker](https://openbroker.gonka.gg); use a [GitHub allow-list issue as a fallback](quickstart.md#fallback--github-allow-list-request) if Open Broker does not satisfy your needs and you still need your own allow-listed creator address.
+> The allowlist is maintained on-chain through **governance**. You cannot add yourself via `config.devshard.env` or admin settings. Prefer becoming a broker via [Open Broker](https://openbroker.gonka.gg); use a [GitHub allow-list issue as a fallback](quickstart.md#fallback-github-allow-list-request) if Open Broker does not satisfy your needs and you still need your own allow-listed creator address.
 >
 > After you import your key in [§2.3](#23-import-the-creator-key), verify membership in [§2.4](#24-confirm-allowlist-membership). Do not fund the creator or deploy the gateway until that check passes (funding alone does not grant allowlist access).
 
@@ -208,7 +208,7 @@ The name `devshard-create` is only a local label; on-chain transactions use `--f
 
 **Do not skip this step.** Escrow creation in [§4](#4-create-an-escrow-and-open-api-access) only succeeds when `$DEVSHARD_CREATOR` is on the chain allowlist.
 
-You do **not** need to run a validator to use a gateway; you only need your creator address on `devshard_escrow_params.allowed_creator_addresses`. If it is missing, stop here - become a broker via [Open Broker](https://openbroker.gonka.gg), or use the [GitHub allow-list fallback](quickstart.md#fallback--github-allow-list-request) only if Open Broker cannot meet your needs. Re-run this check after any governance vote before creating an escrow.
+You do **not** need to run a validator to use a gateway; you only need your creator address on `devshard_escrow_params.allowed_creator_addresses`. If it is missing, stop here - become a broker via [Open Broker](https://openbroker.gonka.gg), or use the [GitHub allow-list fallback](quickstart.md#fallback-github-allow-list-request) only if Open Broker cannot meet your needs. Re-run this check after any governance vote before creating an escrow.
 
 ```bash
 source config.devshard.env
@@ -670,6 +670,6 @@ Replacing the gateway **image** or recreating the main container would drop in-f
 
 ## Related
 
-- [Developer Quickstart](quickstart.md) - community brokers; [become a broker via Open Broker](quickstart.md#recommended--become-a-broker-with-open-broker); [GitHub allow-list fallback](quickstart.md#fallback--github-allow-list-request)
+- [Developer Quickstart](quickstart.md) - community brokers; [become a broker via Open Broker](quickstart.md#recommended-become-a-broker-with-open-broker); [GitHub allow-list fallback](quickstart.md#fallback-github-allow-list-request)
 
 **Need help?** See the [FAQ](https://gonka.ai/FAQ/), join [Discord](https://discord.com/invite/RADwCT2U6R), or - only if Open Broker does not fit - open a [gateway allowlist request](https://github.com/gonka-ai/gonka/issues/new?title=Gateway+allowlist+request) on GitHub.

--- a/docs/developer/quickstart.md
+++ b/docs/developer/quickstart.md
@@ -4,7 +4,7 @@ name: index.md
 
 # Developer Quickstart
 
-This guide explains how to send an inference request to Gonka through a community broker. **[Open Broker](https://openbroker.gonka.gg) is the recommended starting point** for most developers. If you would like to [run your own gateway](#2-run-your-own-gateway-advanced) instead of going through a broker, see Run your own gateway at the bottom of this page.
+This guide explains how to send an inference request to Gonka through a community broker. It is the fastest way to start using the network today. If you would like to [run your own gateway](#2-run-your-own-gateway-advanced) instead of going through a broker, see Run your own gateway at the bottom of this page. Want to **operate as a broker** yourself? See [Interested in operating a gateway?](#3-interested-in-operating-a-gateway) — the recommended path is [Open Broker](https://openbroker.gonka.gg), not a GitHub allow-list issue.
 
 !!! note "How to connect to Gonka"
 
@@ -35,17 +35,6 @@ A broker is an independent operator who runs a Gonka gateway and resells inferen
 
 ### 1.1 Pick a broker
 
-!!! tip "Recommended starting point — Open Broker"
-
-    For most developers, start with **[Open Broker](https://openbroker.gonka.gg)** ([openbroker.gonka.gg](https://openbroker.gonka.gg)) — a community broker created and operated by trusted community members. Sign up, create an API key, and use the OpenAI-compatible endpoint below. **No allow-listed wallet is required.**
-
-    - UI / signup: `https://openbroker.gonka.gg`
-    - API base URL: `https://api.openbroker.gonka.gg/v1`
-    - Docs: [openbroker.gonka.gg/docs](https://openbroker.gonka.gg/docs)
-
-Other community brokers (directory order is shuffled on each page load — not a ranking):
-
-- [https://openbroker.gonka.gg/](https://openbroker.gonka.gg/)
 - [https://gonka24.com/](https://gonka24.com/)
 - [https://proxy.gonka.gg/](https://proxy.gonka.gg/) · [▶ demo](https://drive.google.com/file/d/1-Zk__4cY_ENi0Q8gw-JHgEBz6XZWXKAj/view?pli=1)
 - [https://gonkagate.com/](https://gonkagate.com/)  · [▶ demo](https://www.youtube.com/watch?v=uqeN4J1TFV8)
@@ -58,7 +47,7 @@ Other community brokers (directory order is shuffled on each page load — not a
 - [https://inference.dahl.global](https://inference.dahl.global)
 
 ??? note "About this list"
-    This is a curated directory of community brokers that route inference through a public Gonka gateway and have agreed to be publicly listed. It is not exhaustive and does not endorse any operator. The list is displayed in a random order that is re-shuffled on every page load, so the position of each broker is not a ranking; please evaluate each operator on its own merits. **[Open Broker](https://openbroker.gonka.gg) is the recommended first stop** for new developers (see the tip above). Self-hosting a gateway or requesting on-chain allow-list access is an advanced path — see [Interested in operating a gateway?](#3-interested-in-operating-a-gateway). Some brokers provide a **▶ demo** link to a short onboarding screencast — style and length may vary.
+    This is a curated directory of community brokers that route inference through a public Gonka gateway and have agreed to be publicly listed. It is not exhaustive and does not endorse any operator. The list is displayed in a random order that is re-shuffled on every page load, so the position of each broker is not a ranking; please evaluate each operator on its own merits. This directory reflects an early bootstrap set. **Want to become a broker yourself?** Do not start with a GitHub allow-list issue — use [Open Broker](https://openbroker.gonka.gg) (see [§3](#3-interested-in-operating-a-gateway)). Some brokers provide a **▶ demo** link to a short onboarding screencast — style and length may vary.
 
 ??? tip "Compare brokers — community observability dashboards"
 
@@ -314,17 +303,17 @@ Tool calling is supported through the same OpenAI-compatible endpoint. Only `typ
 
 ## 2. Run your own gateway (advanced)
 
-If a community broker cannot meet your requirements (for example compliance constraints, direct on-chain GNK settlement, or custom routing), you can run a Gonka gateway yourself. The gateway is a small program (shipped as a Docker container) that you run on your own machine or server — never on a Gonka host. It exposes the same OpenAI-compatible API as a broker, but you own the keys, and you pay GNK directly on-chain for the devshards it creates.
+If you need to operate an on-chain Gonka gateway yourself (your own allow-listed wallet, your own escrows, direct GNK settlement), you can run the gateway software on your own machine or server — never on a Gonka host. It exposes the same OpenAI-compatible API as a broker, but you own the keys and pay GNK directly on-chain for the devshards it creates.
 
-!!! tip "Prefer Open Broker unless you specifically need self-hosting"
+!!! tip "Most operators should become a broker via Open Broker instead"
 
-    Most teams should start with **[Open Broker](https://openbroker.gonka.gg)** ([§1.1](#11-pick-a-broker)) instead of self-hosting. Open Broker is a community broker created and operated by trusted community members; it provides production inference access without an allow-listed wallet.
+    **[Open Broker](https://openbroker.gonka.gg) is not “just another broker in the directory.”** It is infrastructure created and operated by trusted community members that lets you **become a broker** — create a broker account, fund GNK, issue API keys, and serve inference — **without** an on-chain allow-listed creator address and without running your own gateway.
 
-    Continue with this section only if Open Broker (or another broker in [§1.1](#11-pick-a-broker)) does not fit your use case.
+    Prefer [§3](#3-interested-in-operating-a-gateway) (Open Broker) unless you specifically need a self-hosted, allow-listed gateway.
 
 !!! warning "Self-hosted gateway requires an allow-listed address"
 
-    Today, only Gonka accounts on the on-chain `devshard_escrow_params.allowed_creator_addresses` list can open devshards. If your address is not on that list, your gateway cannot create sessions, and you cannot send inference. The allow-list is changed only by on-chain governance vote. See [Interested in operating a gateway?](#3-interested-in-operating-a-gateway) below.
+    Today, only Gonka accounts on the on-chain `devshard_escrow_params.allowed_creator_addresses` list can open devshards. If your address is not on that list, your gateway cannot create sessions, and you cannot send inference. The allow-list is changed only by on-chain governance vote. See [Interested in operating a gateway?](#3-interested-in-operating-a-gateway) below — a GitHub issue is a **fallback**, not the default path.
 
 Full deployment instructions are in [Run your own gateway](gateway-developer-quickstart.md).
 
@@ -332,19 +321,29 @@ Full deployment instructions are in [Run your own gateway](gateway-developer-qui
 
 ## 3. Interested in operating a gateway?
 
-Inference reaches the network through a gateway. Choose the path that matches your needs:
+Inference reaches the network through a gateway. If you want to **become a broker / operate inference access** for yourself or your users, choose the path below.
 
-1. **Recommended — use Open Broker.** For most new developers and operators who need inference access today, start with **[Open Broker](https://openbroker.gonka.gg)**. It is a community broker created and operated by trusted community members, exposes an OpenAI-compatible API, and does **not** require an on-chain allow-listed creator address. Sign up at [openbroker.gonka.gg](https://openbroker.gonka.gg) and follow [§1](#1-use-a-community-broker-recommended).
+### Recommended — become a broker with Open Broker
 
-2. **Use another community broker.** See the directory in [§1.1](#11-pick-a-broker). Brokers are independent operators; compare pricing, models, and terms yourself.
+**[Open Broker](https://openbroker.gonka.gg)** ([openbroker.gonka.gg](https://openbroker.gonka.gg)) is the **recommended way to become a broker**.
 
-3. **Run your own gateway (advanced).** Operate your own on-chain devshard gateway when a broker cannot meet your requirements. This requires your address on the governance-controlled allow-list (`devshard_escrow_params.allowed_creator_addresses`). Full instructions are in the [gateway guide](gateway-developer-quickstart.md).
+It is a broker control plane created and operated by trusted community members: you register a **broker account**, deposit GNK, mint API keys, and serve an OpenAI-compatible endpoint. Open Broker runs the allow-listed escrow wallet and devshard lifecycle for you — you do **not** need your address on `allowed_creator_addresses`, and you do **not** need to open a GitHub allow-list issue.
 
-### Fallback: request on-chain allow-list consideration
+- Register: [openbroker.gonka.gg/register](https://openbroker.gonka.gg/register)
+- Docs: [openbroker.gonka.gg/docs](https://openbroker.gonka.gg/docs)
+- API base URL (after you create keys): `https://api.openbroker.gonka.gg/v1`
 
-Open a [GitHub issue](https://github.com/gonka-ai/gonka/issues/new?title=Gateway+allowlist+request) **only if** Open Broker (or another community broker) does not fit your use case, does not work for you, or cannot meet a specific requirement.
+### Advanced — run your own on-chain gateway
+
+Operate your own gonka-mainnet gateway only if Open Broker cannot meet your requirements (for example you must hold the escrow keys yourself, or you need a custom on-chain setup). This requires your address on the governance-controlled allow-list (`devshard_escrow_params.allowed_creator_addresses`). Full instructions are in the [gateway guide](gateway-developer-quickstart.md).
+
+### Fallback — GitHub allow-list request
+
+Open a [GitHub issue](https://github.com/gonka-ai/gonka/issues/new?title=Gateway+allowlist+request) **only if** Open Broker does not fit your use case, does not work for you, or cannot meet a specific requirement — and you still need your own allow-listed creator address for a self-hosted gateway.
 
 Include your operator name and contact, the `gonka1...` address you intend to use, and the models you plan to serve. Inclusion is an on-chain governance decision — no single operator or organization adds an address unilaterally — and expressing interest does not guarantee inclusion, review, or a timeline.
+
+Do **not** open an allow-list issue as the first step. Start with [Open Broker](https://openbroker.gonka.gg).
 
 ---
 

--- a/docs/developer/quickstart.md
+++ b/docs/developer/quickstart.md
@@ -4,7 +4,7 @@ name: index.md
 
 # Developer Quickstart
 
-This guide explains how to send an inference request to Gonka through a community broker. It is the fastest way to start using the network today. If you would like to [run your own gateway](#2-run-your-own-gateway-advanced) instead of going through a broker, see Run your own gateway at the bottom of this page. Want to **operate as a broker** yourself? See [Interested in operating a gateway?](#3-interested-in-operating-a-gateway) — start with [Open Broker](https://openbroker.gonka.gg), or use a GitHub allow-list issue as a fallback if Open Broker does not satisfy your needs.
+This guide explains how to send an inference request to Gonka through a community broker. It is the fastest way to start using the network today. If you would like to [run your own gateway](#2-run-your-own-gateway-advanced) instead of going through a broker, see Run your own gateway at the bottom of this page. Want to **operate as a broker** yourself? See [Interested in operating a gateway?](#3-interested-in-operating-a-gateway) - start with [Open Broker](https://openbroker.gonka.gg), or use a GitHub allow-list issue as a fallback if Open Broker does not satisfy your needs.
 
 !!! note "How to connect to Gonka"
 
@@ -47,7 +47,7 @@ A broker is an independent operator who runs a Gonka gateway and resells inferen
 - [https://inference.dahl.global](https://inference.dahl.global)
 
 ??? note "About this list"
-    This is a curated directory of community brokers that route inference through a public Gonka gateway and have agreed to be publicly listed. It is not exhaustive and does not endorse any operator. The list is displayed in a random order that is re-shuffled on every page load, so the position of each broker is not a ranking; please evaluate each operator on its own merits. This directory reflects an early bootstrap set. **Want to become a broker yourself?** Use [Open Broker](https://openbroker.gonka.gg) (see [§3](#3-interested-in-operating-a-gateway)), or open a GitHub allow-list issue as a fallback if Open Broker does not satisfy your needs. Some brokers provide a **▶ demo** link to a short onboarding screencast — style and length may vary.
+    This is a curated directory of community brokers that route inference through a public Gonka gateway and have agreed to be publicly listed. It is not exhaustive and does not endorse any operator. The list is displayed in a random order that is re-shuffled on every page load, so the position of each broker is not a ranking; please evaluate each operator on its own merits. This directory reflects an early bootstrap set. **Want to become a broker yourself?** Use [Open Broker](https://openbroker.gonka.gg) (see [§3](#3-interested-in-operating-a-gateway)), or open a GitHub allow-list issue as a fallback if Open Broker does not satisfy your needs. Some brokers provide a **▶ demo** link to a short onboarding screencast - style and length may vary.
 
 ??? tip "Compare brokers — community observability dashboards"
 
@@ -303,17 +303,17 @@ Tool calling is supported through the same OpenAI-compatible endpoint. Only `typ
 
 ## 2. Run your own gateway (advanced)
 
-If you need to operate an on-chain Gonka gateway yourself (your own allow-listed wallet, your own escrows, direct GNK settlement), you can run the gateway software on your own machine or server — never on a Gonka host. It exposes the same OpenAI-compatible API as a broker, but you own the keys and pay GNK directly on-chain for the devshards it creates.
+If you need to operate an on-chain Gonka gateway yourself (your own allow-listed wallet, your own escrows, direct GNK settlement), you can run the gateway software on your own machine or server - never on a Gonka host. It exposes the same OpenAI-compatible API as a broker, but you own the keys and pay GNK directly on-chain for the devshards it creates.
 
 !!! tip "Most operators should become a broker via Open Broker instead"
 
-    **[Open Broker](https://openbroker.gonka.gg) is not “just another broker in the directory.”** It is infrastructure created and operated by trusted community members that lets you **become a broker** — create a broker account, fund GNK, issue API keys, and serve inference — **without** an on-chain allow-listed creator address and without running your own gateway.
+    **[Open Broker](https://openbroker.gonka.gg) is not “just another broker in the directory.”** It is infrastructure created and operated by trusted community members that lets you **become a broker** - create a broker account, fund GNK, issue API keys, and serve inference - **without** an on-chain allow-listed creator address and without running your own gateway.
 
     Prefer [§3](#3-interested-in-operating-a-gateway) (Open Broker) unless you specifically need a self-hosted, allow-listed gateway.
 
 !!! warning "Self-hosted gateway requires an allow-listed address"
 
-    Today, only Gonka accounts on the on-chain `devshard_escrow_params.allowed_creator_addresses` list can open devshards. If your address is not on that list, your gateway cannot create sessions, and you cannot send inference. The allow-list is changed only by on-chain governance vote. See [Interested in operating a gateway?](#3-interested-in-operating-a-gateway) — start with Open Broker, or use a GitHub allow-list issue as a fallback if Open Broker does not satisfy your needs.
+    Today, only Gonka accounts on the on-chain `devshard_escrow_params.allowed_creator_addresses` list can open devshards. If your address is not on that list, your gateway cannot create sessions, and you cannot send inference. The allow-list is changed only by on-chain governance vote. See [Interested in operating a gateway?](#3-interested-in-operating-a-gateway) - start with Open Broker, or use a GitHub allow-list issue as a fallback if Open Broker does not satisfy your needs.
 
 Full deployment instructions are in [Run your own gateway](gateway-developer-quickstart.md).
 
@@ -323,25 +323,25 @@ Full deployment instructions are in [Run your own gateway](gateway-developer-qui
 
 Inference reaches the network through a gateway. If you want to **become a broker / operate inference access** for yourself or your users, choose the path below.
 
-### Recommended — become a broker with Open Broker
+### Recommended - become a broker with Open Broker
 
 **[Open Broker](https://openbroker.gonka.gg)** ([openbroker.gonka.gg](https://openbroker.gonka.gg)) is the **recommended way to become a broker**.
 
-It is a broker control plane created and operated by trusted community members: you register a **broker account**, deposit GNK, mint API keys, and serve an OpenAI-compatible endpoint. Open Broker runs the allow-listed escrow wallet and devshard lifecycle for you — you do not need your address on `allowed_creator_addresses`.
+It is a broker control plane created and operated by trusted community members: you register a **broker account**, deposit GNK, mint API keys, and serve an OpenAI-compatible endpoint. Open Broker runs the allow-listed escrow wallet and devshard lifecycle for you - you do not need your address on `allowed_creator_addresses`.
 
 - Register: [openbroker.gonka.gg/register](https://openbroker.gonka.gg/register)
 - Docs: [openbroker.gonka.gg/docs](https://openbroker.gonka.gg/docs)
 - API base URL (after you create keys): `https://api.openbroker.gonka.gg/v1`
 
-### Advanced — run your own on-chain gateway
+### Advanced - run your own on-chain gateway
 
 Operate your own gonka-mainnet gateway only if Open Broker cannot meet your requirements (for example you must hold the escrow keys yourself, or you need a custom on-chain setup). This requires your address on the governance-controlled allow-list (`devshard_escrow_params.allowed_creator_addresses`). Full instructions are in the [gateway guide](gateway-developer-quickstart.md).
 
-### Fallback — GitHub allow-list request
+### Fallback - GitHub allow-list request
 
 If Open Broker does not satisfy your needs and you still require your own allow-listed creator address for a self-hosted gateway, open a [GitHub issue](https://github.com/gonka-ai/gonka/issues/new?title=Gateway+allowlist+request) as a fallback.
 
-Include your operator name and contact, the `gonka1...` address you intend to use, and the models you plan to serve. Inclusion is an on-chain governance decision — no single operator or organization adds an address unilaterally — and expressing interest does not guarantee inclusion, review, or a timeline.
+Include your operator name and contact, the `gonka1...` address you intend to use, and the models you plan to serve. Inclusion is an on-chain governance decision - no single operator or organization adds an address unilaterally - and expressing interest does not guarantee inclusion, review, or a timeline.
 
 ---
 

--- a/docs/developer/quickstart.md
+++ b/docs/developer/quickstart.md
@@ -4,7 +4,7 @@ name: index.md
 
 # Developer Quickstart
 
-This guide explains how to send an inference request to Gonka through a community broker. It is the fastest way to start using the network today. If you would like to [run your own gateway](#2-run-your-own-gateway-advanced) instead of going through a broker, see Run your own gateway at the bottom of this page.
+This guide explains how to send an inference request to Gonka through a community broker. **[Open Broker](https://openbroker.gonka.gg) is the recommended starting point** for most developers. If you would like to [run your own gateway](#2-run-your-own-gateway-advanced) instead of going through a broker, see Run your own gateway at the bottom of this page.
 
 !!! note "How to connect to Gonka"
 
@@ -35,6 +35,17 @@ A broker is an independent operator who runs a Gonka gateway and resells inferen
 
 ### 1.1 Pick a broker
 
+!!! tip "Recommended starting point — Open Broker"
+
+    For most developers, start with **[Open Broker](https://openbroker.gonka.gg)** ([openbroker.gonka.gg](https://openbroker.gonka.gg)) — a community broker created and operated by trusted community members. Sign up, create an API key, and use the OpenAI-compatible endpoint below. **No allow-listed wallet is required.**
+
+    - UI / signup: `https://openbroker.gonka.gg`
+    - API base URL: `https://api.openbroker.gonka.gg/v1`
+    - Docs: [openbroker.gonka.gg/docs](https://openbroker.gonka.gg/docs)
+
+Other community brokers (directory order is shuffled on each page load — not a ranking):
+
+- [https://openbroker.gonka.gg/](https://openbroker.gonka.gg/)
 - [https://gonka24.com/](https://gonka24.com/)
 - [https://proxy.gonka.gg/](https://proxy.gonka.gg/) · [▶ demo](https://drive.google.com/file/d/1-Zk__4cY_ENi0Q8gw-JHgEBz6XZWXKAj/view?pli=1)
 - [https://gonkagate.com/](https://gonkagate.com/)  · [▶ demo](https://www.youtube.com/watch?v=uqeN4J1TFV8)
@@ -47,7 +58,7 @@ A broker is an independent operator who runs a Gonka gateway and resells inferen
 - [https://inference.dahl.global](https://inference.dahl.global)
 
 ??? note "About this list"
-    This is a curated directory of community brokers that route inference through a public Gonka gateway and have agreed to be publicly listed. It is not exhaustive and does not endorse any operator. The list is displayed in a random order that is re-shuffled on every page load, so the position of each broker is not a ranking; please evaluate each operator on its own merits. This directory reflects an early bootstrap set. New operators who want to serve inference independently should see [Interested in operating a gateway?](#3-interested-in-operating-a-gateway). Some brokers provide a **▶ demo** link to a short onboarding screencast — style and length may vary.
+    This is a curated directory of community brokers that route inference through a public Gonka gateway and have agreed to be publicly listed. It is not exhaustive and does not endorse any operator. The list is displayed in a random order that is re-shuffled on every page load, so the position of each broker is not a ranking; please evaluate each operator on its own merits. **[Open Broker](https://openbroker.gonka.gg) is the recommended first stop** for new developers (see the tip above). Self-hosting a gateway or requesting on-chain allow-list access is an advanced path — see [Interested in operating a gateway?](#3-interested-in-operating-a-gateway). Some brokers provide a **▶ demo** link to a short onboarding screencast — style and length may vary.
 
 ??? tip "Compare brokers — community observability dashboards"
 
@@ -303,7 +314,13 @@ Tool calling is supported through the same OpenAI-compatible endpoint. Only `typ
 
 ## 2. Run your own gateway (advanced)
 
-If your application has high throughput or other requirements, you can run a Gonka gateway yourself instead of going through a broker. The gateway is a small program (shipped as a Docker container) that you run on your own machine or server — never on a Gonka host. It exposes the same OpenAI-compatible API as a broker, but you own the keys, and you pay GNK directly on-chain for the devshards it creates.
+If a community broker cannot meet your requirements (for example compliance constraints, direct on-chain GNK settlement, or custom routing), you can run a Gonka gateway yourself. The gateway is a small program (shipped as a Docker container) that you run on your own machine or server — never on a Gonka host. It exposes the same OpenAI-compatible API as a broker, but you own the keys, and you pay GNK directly on-chain for the devshards it creates.
+
+!!! tip "Prefer Open Broker unless you specifically need self-hosting"
+
+    Most teams should start with **[Open Broker](https://openbroker.gonka.gg)** ([§1.1](#11-pick-a-broker)) instead of self-hosting. Open Broker is a community broker created and operated by trusted community members; it provides production inference access without an allow-listed wallet.
+
+    Continue with this section only if Open Broker (or another broker in [§1.1](#11-pick-a-broker)) does not fit your use case.
 
 !!! warning "Self-hosted gateway requires an allow-listed address"
 
@@ -315,13 +332,19 @@ Full deployment instructions are in [Run your own gateway](gateway-developer-qui
 
 ## 3. Interested in operating a gateway?
 
-Inference reaches the network through a gateway. There are two ways to have one, and they are governed differently.
+Inference reaches the network through a gateway. Choose the path that matches your needs:
 
-**Use a public gateway (current brokers).** The brokers in [§1.1](#11-pick-a-broker) reach inference through a public Gonka gateway under access arrangements made during the early rollout. That was a bootstrap step, and the directory is not being actively expanded.
+1. **Recommended — use Open Broker.** For most new developers and operators who need inference access today, start with **[Open Broker](https://openbroker.gonka.gg)**. It is a community broker created and operated by trusted community members, exposes an OpenAI-compatible API, and does **not** require an on-chain allow-listed creator address. Sign up at [openbroker.gonka.gg](https://openbroker.gonka.gg) and follow [§1](#1-use-a-community-broker-recommended).
 
-**Run your own gateway.** Operate your own on-chain devshard gateway. This requires your address on the governance-controlled allow-list (`devshard_escrow_params.allowed_creator_addresses`), and it is the recommended path for new operators. Full instructions are in the [gateway guide](gateway-developer-quickstart.md).
+2. **Use another community broker.** See the directory in [§1.1](#11-pick-a-broker). Brokers are independent operators; compare pricing, models, and terms yourself.
 
-To request consideration for on-chain allow-listing, open a [GitHub issue](https://github.com/gonka-ai/gonka/issues/new?title=Gateway+allowlist+request) including your operator name and contact, the `gonka1...` address you intend to use, and the models you plan to serve. Inclusion is an on-chain governance decision — no single operator or organization adds an address unilaterally — and expressing interest does not guarantee inclusion, review, or a timeline.
+3. **Run your own gateway (advanced).** Operate your own on-chain devshard gateway when a broker cannot meet your requirements. This requires your address on the governance-controlled allow-list (`devshard_escrow_params.allowed_creator_addresses`). Full instructions are in the [gateway guide](gateway-developer-quickstart.md).
+
+### Fallback: request on-chain allow-list consideration
+
+Open a [GitHub issue](https://github.com/gonka-ai/gonka/issues/new?title=Gateway+allowlist+request) **only if** Open Broker (or another community broker) does not fit your use case, does not work for you, or cannot meet a specific requirement.
+
+Include your operator name and contact, the `gonka1...` address you intend to use, and the models you plan to serve. Inclusion is an on-chain governance decision — no single operator or organization adds an address unilaterally — and expressing interest does not guarantee inclusion, review, or a timeline.
 
 ---
 

--- a/docs/developer/quickstart.md
+++ b/docs/developer/quickstart.md
@@ -4,7 +4,7 @@ name: index.md
 
 # Developer Quickstart
 
-This guide explains how to send an inference request to Gonka through a community broker. It is the fastest way to start using the network today. If you would like to [run your own gateway](#2-run-your-own-gateway-advanced) instead of going through a broker, see Run your own gateway at the bottom of this page. Want to **operate as a broker** yourself? See [Interested in operating a gateway?](#3-interested-in-operating-a-gateway) — the recommended path is [Open Broker](https://openbroker.gonka.gg), not a GitHub allow-list issue.
+This guide explains how to send an inference request to Gonka through a community broker. It is the fastest way to start using the network today. If you would like to [run your own gateway](#2-run-your-own-gateway-advanced) instead of going through a broker, see Run your own gateway at the bottom of this page. Want to **operate as a broker** yourself? See [Interested in operating a gateway?](#3-interested-in-operating-a-gateway) — start with [Open Broker](https://openbroker.gonka.gg), or use a GitHub allow-list issue as a fallback if Open Broker does not satisfy your needs.
 
 !!! note "How to connect to Gonka"
 
@@ -47,7 +47,7 @@ A broker is an independent operator who runs a Gonka gateway and resells inferen
 - [https://inference.dahl.global](https://inference.dahl.global)
 
 ??? note "About this list"
-    This is a curated directory of community brokers that route inference through a public Gonka gateway and have agreed to be publicly listed. It is not exhaustive and does not endorse any operator. The list is displayed in a random order that is re-shuffled on every page load, so the position of each broker is not a ranking; please evaluate each operator on its own merits. This directory reflects an early bootstrap set. **Want to become a broker yourself?** Do not start with a GitHub allow-list issue — use [Open Broker](https://openbroker.gonka.gg) (see [§3](#3-interested-in-operating-a-gateway)). Some brokers provide a **▶ demo** link to a short onboarding screencast — style and length may vary.
+    This is a curated directory of community brokers that route inference through a public Gonka gateway and have agreed to be publicly listed. It is not exhaustive and does not endorse any operator. The list is displayed in a random order that is re-shuffled on every page load, so the position of each broker is not a ranking; please evaluate each operator on its own merits. This directory reflects an early bootstrap set. **Want to become a broker yourself?** Use [Open Broker](https://openbroker.gonka.gg) (see [§3](#3-interested-in-operating-a-gateway)), or open a GitHub allow-list issue as a fallback if Open Broker does not satisfy your needs. Some brokers provide a **▶ demo** link to a short onboarding screencast — style and length may vary.
 
 ??? tip "Compare brokers — community observability dashboards"
 
@@ -313,7 +313,7 @@ If you need to operate an on-chain Gonka gateway yourself (your own allow-listed
 
 !!! warning "Self-hosted gateway requires an allow-listed address"
 
-    Today, only Gonka accounts on the on-chain `devshard_escrow_params.allowed_creator_addresses` list can open devshards. If your address is not on that list, your gateway cannot create sessions, and you cannot send inference. The allow-list is changed only by on-chain governance vote. See [Interested in operating a gateway?](#3-interested-in-operating-a-gateway) below — a GitHub issue is a **fallback**, not the default path.
+    Today, only Gonka accounts on the on-chain `devshard_escrow_params.allowed_creator_addresses` list can open devshards. If your address is not on that list, your gateway cannot create sessions, and you cannot send inference. The allow-list is changed only by on-chain governance vote. See [Interested in operating a gateway?](#3-interested-in-operating-a-gateway) — start with Open Broker, or use a GitHub allow-list issue as a fallback if Open Broker does not satisfy your needs.
 
 Full deployment instructions are in [Run your own gateway](gateway-developer-quickstart.md).
 
@@ -327,7 +327,7 @@ Inference reaches the network through a gateway. If you want to **become a broke
 
 **[Open Broker](https://openbroker.gonka.gg)** ([openbroker.gonka.gg](https://openbroker.gonka.gg)) is the **recommended way to become a broker**.
 
-It is a broker control plane created and operated by trusted community members: you register a **broker account**, deposit GNK, mint API keys, and serve an OpenAI-compatible endpoint. Open Broker runs the allow-listed escrow wallet and devshard lifecycle for you — you do **not** need your address on `allowed_creator_addresses`, and you do **not** need to open a GitHub allow-list issue.
+It is a broker control plane created and operated by trusted community members: you register a **broker account**, deposit GNK, mint API keys, and serve an OpenAI-compatible endpoint. Open Broker runs the allow-listed escrow wallet and devshard lifecycle for you — you do not need your address on `allowed_creator_addresses`.
 
 - Register: [openbroker.gonka.gg/register](https://openbroker.gonka.gg/register)
 - Docs: [openbroker.gonka.gg/docs](https://openbroker.gonka.gg/docs)
@@ -339,11 +339,9 @@ Operate your own gonka-mainnet gateway only if Open Broker cannot meet your requ
 
 ### Fallback — GitHub allow-list request
 
-Open a [GitHub issue](https://github.com/gonka-ai/gonka/issues/new?title=Gateway+allowlist+request) **only if** Open Broker does not fit your use case, does not work for you, or cannot meet a specific requirement — and you still need your own allow-listed creator address for a self-hosted gateway.
+If Open Broker does not satisfy your needs and you still require your own allow-listed creator address for a self-hosted gateway, open a [GitHub issue](https://github.com/gonka-ai/gonka/issues/new?title=Gateway+allowlist+request) as a fallback.
 
 Include your operator name and contact, the `gonka1...` address you intend to use, and the models you plan to serve. Inclusion is an on-chain governance decision — no single operator or organization adds an address unilaterally — and expressing interest does not guarantee inclusion, review, or a timeline.
-
-Do **not** open an allow-list issue as the first step. Start with [Open Broker](https://openbroker.gonka.gg).
 
 ---
 


### PR DESCRIPTION
## Summary

[Open Broker](https://openbroker.gonka.gg) is the **recommended way to become a broker** - register a broker account, deposit GNK, issue keys, serve inference - without an on-chain allow-listed creator address. It is **not** presented as just another community broker in the §1.1 directory.

| Path | Role |
|---|---|
| **[Open Broker](https://openbroker.gonka.gg)** | Recommended way to **become / operate as a broker** |
| **Self-hosted gateway** | Advanced; needs `allowed_creator_addresses` |
| **GitHub allow-list issue** | Fallback when Open Broker does not satisfy your needs |

### Changes
- §2 / §3 rewritten around "become a broker via Open Broker"
- §1.1 directory left as consumer brokers; note points aspiring operators to §3
- Gateway developer guide cross-links updated to match

## Test plan
- [ ] Read §3 aloud: is "become a broker" unambiguous?
- [ ] Confirm GitHub issue is clearly labeled fallback
- [ ] Confirm Open Broker is not pitched as a §1.1 consumer pick